### PR TITLE
Add --grep option to run a subset of test files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@open-wc/testing": "^3",
         "@web/test-runner": "^0.16",
         "@web/test-runner-commands": "^0.7",
-        "@web/test-runner-playwright": "^0.10"
+        "@web/test-runner-playwright": "^0.10",
+        "command-line-args": "^5"
       },
       "devDependencies": {
         "chai": "^4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@open-wc/testing": "^3",
     "@web/test-runner": "^0.16",
     "@web/test-runner-commands": "^0.7",
-    "@web/test-runner-playwright": "^0.10"
+    "@web/test-runner-playwright": "^0.10",
+    "command-line-args": "^5"
   }
 }

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -1,6 +1,15 @@
+import commandLineArgs from 'command-line-args';
 import { defaultReporter } from '@web/test-runner';
 import { playwrightLauncher } from '@web/test-runner-playwright';
-import { readCliArgs } from '../../node_modules/@web/test-runner/dist/config/readCliArgs.js';
+
+const optionDefinitions = [
+	{ name: 'playwright', type: Boolean },
+	{ name: 'files', type: String, multiple: true, defaultOption: true },
+	{ name: 'group', type: String },
+	{ name: 'grep', alias: 'g', type: String, multiple: true }
+];
+
+const cliArgs = commandLineArgs(optionDefinitions, { partial: true });
 
 const DEFAULT_PATTERN = type => `./test/**/*.${type}.js`;
 const DEFAULT_VDIFF = false;
@@ -64,8 +73,8 @@ export class WTRConfig {
 
 	#getPattern(type) {
 		const pattern = this.pattern(type);
-		// if --files provided, require single-segment wildcards to match
-		return this.#cliArgs.files?.map(f => pattern.replace(/(?<!\*)\*(?!\*)/g, `*${f}*`)) || pattern;
+		// if --grep provided, require single-segment wildcards to match
+		return this.#cliArgs.grep?.map(g => pattern.replace(/(?<!\*)\*(?!\*)/g, `*${g}*`)) || pattern;
 	}
 
 	create({
@@ -158,11 +167,11 @@ export class WTRConfig {
 }
 
 export function createConfig(...args) {
-	const wtrConfig = new WTRConfig(readCliArgs());
+	const wtrConfig = new WTRConfig(cliArgs);
 	return wtrConfig.create(...args);
 }
 
 export function getBrowsers(browsers) {
-	const wtrConfig = new WTRConfig(readCliArgs());
+	const wtrConfig = new WTRConfig(cliArgs);
 	return wtrConfig.getBrowsers(browsers);
 }

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -75,7 +75,7 @@ export class WTRConfig {
 		...passthroughConfig
 	} = {}) {
 
-		if (!this.#cliArgs.group?.length || this.#cliArgs.group?.includes('default')) {
+		if (!this.#cliArgs.group || this.#cliArgs.group === 'default') {
 			if (this.#cliArgs.playwright) {
 				console.warn('Warning: reducedMotion disabled. Use the unit group to enable reducedMotion.');
 			} else {

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -99,9 +99,9 @@ describe('createWtrConfig', () => {
 
 		it('should filter test files using --files values', () => {
 			wtrConfig = new WTRConfig({ grep: ['subset', 'subset2'] });
-			config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.js` });
+			config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.*` });
 			expect(config.files).to.have.length(2);
-			expect(config.files).to.have.members(['./test/**/*subset*/*subset*.test.js', './test/**/*subset2*/*subset2*.test.js']);
+			expect(config.files).to.have.members(['./test/**/*/(*subset*.test.*|*.test.*subset*)', './test/**/*/(*subset2*.test.*|*.test.*subset2*)']);
 		});
 
 	});

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -57,7 +57,7 @@ describe('createWtrConfig', () => {
 
 		it('should warn about not using a group with playwright', () => {
 			const consoleSpy = spy(console, 'warn');
-			wtrConfig = new WTRConfig(['--playwright']);
+			wtrConfig = new WTRConfig({ playwright: true });
 			wtrConfig.create();
 			assert.calledOnce(consoleSpy);
 			assert.calledWith(consoleSpy, match('Warning: reducedMotion disabled.'));
@@ -95,6 +95,13 @@ describe('createWtrConfig', () => {
 		it('should not enable vdiff by default', () => {
 			expect(config.groups).to.be.an('array').that.has.length(1);
 			expect(config.groups[0]).to.not.have.property('name', 'vdiff');
+		});
+
+		it('should filter test files using --files values', () => {
+			wtrConfig = new WTRConfig({ files: ['subset', 'subset2'] });
+			config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.js` });
+			expect(config.files).to.have.length(2);
+			expect(config.files).to.have.members(['./test/**/*subset*/*subset*.test.js', './test/**/*subset2*/*subset2*.test.js']);
 		});
 
 	});
@@ -139,7 +146,7 @@ describe('createWtrConfig', () => {
 		});
 
 		it('should only use CLI browsers when provided', () => {
-			const wtrConfig = new WTRConfig(['a', 'firefox', 'webkit', 'b']);
+			const wtrConfig = new WTRConfig({ browsers: ['a', 'firefox', 'webkit', 'b'] });
 			const browsers = wtrConfig.getBrowsers(['chromium']);
 			expect(browsers).to.have.length(2);
 			expect(browsers.map(b => b.name)).to.have.members(['Webkit', 'Firefox']);

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -98,7 +98,7 @@ describe('createWtrConfig', () => {
 		});
 
 		it('should filter test files using --files values', () => {
-			wtrConfig = new WTRConfig({ files: ['subset', 'subset2'] });
+			wtrConfig = new WTRConfig({ grep: ['subset', 'subset2'] });
 			config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.js` });
 			expect(config.files).to.have.length(2);
 			expect(config.files).to.have.members(['./test/**/*subset*/*subset*.test.js', './test/**/*subset2*/*subset2*.test.js']);

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -97,7 +97,7 @@ describe('createWtrConfig', () => {
 			expect(config.groups[0]).to.not.have.property('name', 'vdiff');
 		});
 
-		it('should filter test files using --files values', () => {
+		it('should filter test files using --grep values', () => {
 			wtrConfig = new WTRConfig({ grep: ['subset', 'subset2'] });
 			config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.*` });
 			expect(config.files).to.have.length(2);


### PR DESCRIPTION
[US152300](https://rally1.rallydev.com/#/?detail=/userstory/699970845705&fdp=true): Visual-diff: run a subset of tests

Allows any library-created `group` to run a subset of test files by modifying the `pattern` with values from the `--grep` (`-g`) CLI arg.

`npm run test:visual-diff -- -g button list` would modify the pattern `./test/**/*.vdiff.js` to `['./test/**/*button*.vdiff.js', './test/**/*list*.vdiff.js']`.
