### PR TITLE
feat: export focusWithKeyboard, focusWithMouse & assert

### DIFF
--- a/src/browser/focus.js
+++ b/src/browser/focus.js
@@ -1,6 +1,12 @@
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 
-export const focusWithKeyboard = async(element) => {
-	await sendKeys({ press: 'Escape' });
+export async function focusWithKeyboard(element) {
+	await sendKeys({ press: 'Shift' }); // Tab moves focus, Escape causes dismissible things to close
 	element.focus({ focusVisible: true });
-};
+}
+
+export async function focusWithMouse(element) {
+	const { x, y } = element.getBoundingClientRect();
+	await sendMouse({ type: 'click', position: [Math.ceil(x), Math.ceil(y)] });
+	await sendMouse({ type: 'move', position: [0, 0] });
+}

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,2 +1,3 @@
-export { aTimeout, defineCE, expect, html, nextFrame, oneEvent, waitUntil } from '@open-wc/testing';
+export { assert, aTimeout, defineCE, expect, html, nextFrame, oneEvent, waitUntil } from '@open-wc/testing';
+export { focusWithKeyboard, focusWithMouse } from './focus.js';
 export { fixture } from './fixture.js';


### PR DESCRIPTION
Core needs these, so adding them here & exporting. I'll delete [core's copy](https://github.com/BrightspaceUI/core/blob/main/tools/web-test-runner-helpers.js) once it's switched over to use this since it doesn't appear to be used outside of core.