### PR TITLE
Fix filter bug + vars

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -128,20 +128,20 @@ export class WTRConfig {
 	#getPattern(type) {
 		const pattern = this.#cliArgs.files || this.pattern(type);
 
-		// replace filename wildcards with all grep strings
-		// e.g. If grep is ['button', 'list'], pattern './test/*.test.*' becomes:
-		// [ './test/(*button*.test.*|*.test.*button*)', './test/(*list*.test.*|*.test.*list*)' ]
+		// replace filename wildcards with all filter strings
+		// e.g. If filter is ['button', 'list'], pattern './test/*.test.*' becomes:
+		// [ './test/+(*button*.test.*|*.test.*button*)', './test/+(*list*.test.*|*.test.*list*)' ]
 		if (this.#cliArgs.filter) {
-			return this.#cliArgs.filter.map(grepStr => {
+			return this.#cliArgs.filter.map(filterStr => {
 				// replace everything after the last forward slash
 				return pattern.replace(/[^/]*$/, fileGlob => {
 					// create a new glob for each wildcard
 					const fileGlobs = Array.from(fileGlob.matchAll(/(?<!\*)\*(?!\*)/g)).map(({ index }) => {
 						const arr = fileGlob.split('');
-						arr.splice(index, 1, `*${grepStr}*`);
+						arr.splice(index, 1, `*${filterStr}*`);
 						return arr.join('');
 					});
-					return `(${fileGlobs.join('|')})`;
+					return `+(${fileGlobs.join('|')})`;
 				});
 			});
 		}

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -124,7 +124,7 @@ describe('createWtrConfig', () => {
 			const wtrConfig = new WTRConfig({ filter: ['subset', 'subset2'] });
 			const config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.*` });
 			expect(config.files).to.have.length(2);
-			expect(config.files).to.have.members(['./test/**/*/(*subset*.test.*|*.test.*subset*)', './test/**/*/(*subset2*.test.*|*.test.*subset2*)']);
+			expect(config.files).to.have.members(['./test/**/*/+(*subset*.test.*|*.test.*subset*)', './test/**/*/+(*subset2*.test.*|*.test.*subset2*)']);
 		});
 
 		it('should add --grep value to testFramework config', () => {


### PR DESCRIPTION
This fixes an issue where the glob without a leading `+` would not find any test files. Also, when the old `grep` was renamed to `filter` some references were missed.