### PR TITLE
fix: reduce Firefox's concurrency to 1 to avoid unreliable focus

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -213,6 +213,7 @@ export class WTRConfig {
 		if (!Array.isArray(browsers)) throw new TypeError('browsers must be an array');
 
 		return browsers.map((b) => playwrightLauncher({
+			concurrency: b === 'firefox' ? 1 : undefined, // focus in Firefox unreliable if concurrency > 1 (https://github.com/modernweb-dev/web/issues/238)
 			product: b,
 			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor: 2, reducedMotion: 'reduce' })
 		}));


### PR DESCRIPTION
Stacey discovered [this issue](https://github.com/modernweb-dev/web/issues/238) which describes exactly the situation I was seeing in some of the core tests. On my local machine (where concurrency is high), focus would randomly leave the window under test, causing random failures.

This reduces concurrency on Firefox to 1 to avoid this issue. I think this will have a minimal effect in CI where our runners don't have a lot of cores anyway.