### PR TITLE
feat: move elem argument first

### DIFF
--- a/src/browser/commands.js
+++ b/src/browser/commands.js
@@ -37,7 +37,7 @@ export async function sendKeys(action, keys) {
 	await cmdSendKeys(val);
 }
 
-export async function sendKeysElem(action, keys, elem) {
+export async function sendKeysElem(elem, action, keys) {
 	if (elem) {
 		await focusElem(elem);
 	}

--- a/test/browser/commands.test.js
+++ b/test/browser/commands.test.js
@@ -58,7 +58,7 @@ describe('commands', () => {
 	});
 
 	it('should send keys to element', async() => {
-		await sendKeysElem('type', 'Hello', elem);
+		await sendKeysElem(elem, 'type', 'Hello');
 		expect(elem.value).to.equal('Hello');
 	});
 


### PR DESCRIPTION
What do folks think about flipping the arguments around here so that `elem` is first? That way it's consistent with `await oneEvent(elem, 'event-name')`.