### PR TITLE
Recreate golden with this before each test

### DIFF
--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -4,16 +4,16 @@ import { executeServerCommand } from '@web/test-runner-commands';
 mocha.setup({ // eslint-disable-line no-undef
 	rootHooks: {
 		beforeEach() {
-			chai.Assertion.addMethod('golden',
-				(test => function(...args) {
-					return ScreenshotAndCompare.call(test, this._obj, ...args); // eslint-disable-line no-invalid-this
-				})(this.currentTest));
+			const { currentTest } = this;
+			chai.Assertion.addMethod('golden', function(...args) {
+				return ScreenshotAndCompare(currentTest, this._obj, ...args); // eslint-disable-line no-invalid-this
+			});
 		}
 	}
 });
 
-async function ScreenshotAndCompare(elem, opts) {
-	const name = this.fullTitle();
+async function ScreenshotAndCompare(test, elem, opts) {
+	const name = test.fullTitle();
 	const rect = elem.getBoundingClientRect();
 	const { pass, message } = await executeServerCommand('brightspace-visual-diff', { name, rect, opts });
 	if (!pass) {

--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -1,10 +1,19 @@
 import { chai, expect } from '@open-wc/testing';
 import { executeServerCommand } from '@web/test-runner-commands';
 
-chai.Assertion.addMethod('golden', ScreenshotAndCompare);
+mocha.setup({ // eslint-disable-line no-undef
+	rootHooks: {
+		beforeEach() {
+			chai.Assertion.addMethod('golden',
+				(test => function(...args) {
+					return ScreenshotAndCompare.call(test, this._obj, ...args); // eslint-disable-line no-invalid-this
+				})(this.currentTest));
+		}
+	}
+});
 
-async function ScreenshotAndCompare(name, opts) {
-	const elem = this._obj;
+async function ScreenshotAndCompare(elem, opts) {
+	const name = this.fullTitle();
 	const rect = elem.getBoundingClientRect();
 	const { pass, message } = await executeServerCommand('brightspace-visual-diff', { name, rect, opts });
 	if (!pass) {

--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -6,15 +6,15 @@ mocha.setup({ // eslint-disable-line no-undef
 		beforeEach() {
 			const { currentTest } = this;
 			chai.Assertion.addMethod('golden', function(...args) {
-				return ScreenshotAndCompare(currentTest, this._obj, ...args); // eslint-disable-line no-invalid-this
+				return ScreenshotAndCompare.call({ test: currentTest, elem: this._obj }, ...args); // eslint-disable-line no-invalid-this
 			});
 		}
 	}
 });
 
-async function ScreenshotAndCompare(test, elem, opts) {
-	const name = test.fullTitle();
-	const rect = elem.getBoundingClientRect();
+async function ScreenshotAndCompare(opts) {
+	const name = this.test.fullTitle();
+	const rect = this.elem.getBoundingClientRect();
 	const { pass, message } = await executeServerCommand('brightspace-visual-diff', { name, rect, opts });
 	if (!pass) {
 		expect.fail(message);

--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -1,13 +1,15 @@
 import { chai, expect } from '@open-wc/testing';
 import { executeServerCommand } from '@web/test-runner-commands';
 
+let test;
+
+chai.Assertion.addMethod('golden', function(...args) {
+	return ScreenshotAndCompare.call({ test, elem: this._obj }, ...args); // eslint-disable-line no-invalid-this
+});
 mocha.setup({ // eslint-disable-line no-undef
 	rootHooks: {
 		beforeEach() {
-			const { currentTest } = this;
-			chai.Assertion.addMethod('golden', function(...args) {
-				return ScreenshotAndCompare.call({ test: currentTest, elem: this._obj }, ...args); // eslint-disable-line no-invalid-this
-			});
+			test = this.currentTest;
 		}
 	}
 });

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -129,8 +129,7 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 				}
 			}
 
-			const opts = payload.opts || {};
-			opts.margin = opts.margin || DEFAULT_MARGIN;
+			const opts = { margin: DEFAULT_MARGIN, ...payload.opts };
 
 			const page = session.browser.getPage(session.id);
 			await page.screenshot({

--- a/test/browser/element.vdiff.js
+++ b/test/browser/element.vdiff.js
@@ -42,10 +42,10 @@ describe('element-matches', () => {
 		{ name: 'rtl', rtl: true },
 		{ name: 'transition', action: elem => elem.style.opacity = '0.2' }
 	].forEach(({ name, rtl, action }) => {
-		it(name, async function() {
+		it(name, async() => {
 			const elem = await fixture(`<${elementTag} text="Visual Difference"></${elementTag}>`, { rtl: rtl });
 			if (action) await action(elem);
-			await expect(elem).to.be.golden(this.test.fullTitle());
+			await expect(elem).to.be.golden();
 		});
 	});
 });
@@ -65,7 +65,7 @@ describe('element-different', () => {
 			elem.style.height = '70px';
 		} }*/
 	].forEach(({ name, action }) => {
-		it(name, async function() {
+		it(name, async() => {
 			const elem = await fixture(`<${elementTag} text="Visual Difference"></${elementTag}>`);
 			const isGolden = await executeServerCommand('vdiff-get-golden-flag');
 			if (!isGolden) {
@@ -75,7 +75,7 @@ describe('element-different', () => {
 
 			let fail = false;
 			try {
-				await expect(elem).to.be.golden(this.test.fullTitle());
+				await expect(elem).to.be.golden();
 			} catch (ex) {
 				fail = true;
 			}


### PR DESCRIPTION
Adds a `beforeEach` root hook to mocha, in which the `golden` assertion method is recreated to call `ScreenshotAndCompare` with the current test and fixture element in `this`.

Avoids needing to pass `this` to `golden()`, which also allows arrow functions to be used.