### PR TITLE
Some small fixes

### DIFF
--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -36,7 +36,8 @@ async function clearAllDirs(updateGoldens, vdiffPath) {
 	if (updateGoldens) {
 		await rm(vdiffPath, { force: true, recursive: true });
 	} else {
-		await clearDiffPaths(vdiffPath);
+		const exists = await checkFileExists(vdiffPath);
+		if (exists) await clearDiffPaths(vdiffPath);
 	}
 }
 

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -94,7 +94,6 @@ export class WTRConfig {
 								font-size: 0.95rem;
 								font-weight: 400;
 								line-height: 1.4rem;
-								margin: 0;
 								padding: 30px;
 							}
 						</style>


### PR DESCRIPTION
1. Match the old width for fullscreen tests as discussed
2. Fix the scenario where you try to run `npm run test:vdiff` before rendering the goldens the first time (meaning the `.vdiff` folder doesn't exist)