### PR TITLE
Turn off minor and patch updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # update-package-lock workflow aready handles minor/patch updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
`update-package-lock` handles these, and dependabot timing looks to be more random these days.