### PR TITLE
fix: Temporarily add logging around how long it takes to reset mouse position

### DIFF
--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -23,7 +23,11 @@ export async function reset(opts) {
 
 	window.scroll(0, 0);
 
+	const startTime = Date.now();
 	await sendMouse({ type: 'move', position: [0, 0] }).catch(() => {});
+	const timeTaken = Date.now() - startTime;
+	// eslint-disable-next-line no-console
+	if (timeTaken > 200) console.log(`*** Took ${timeTaken}ms to reset mouse position.`);
 
 	if (document.activeElement !== document.body) {
 		document.activeElement.blur();


### PR DESCRIPTION
Want to get an idea of how often this happens, if at all, in `core`.