### PR TITLE
Rename reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/BrightspaceUI/testing.git",
   "scripts": {
     "lint": "eslint . --ext .js",
-    "start": "web-dev-server --root-dir ./.vdiff --open ./report/",
+    "start": "web-dev-server --root-dir ./.vdiff --open ./.report/",
     "test": "npm run lint && npm run test:server && npm run test:browser",
     "test:browser": "web-test-runner --files \"./test/browser/**/*.test.js\" --node-resolve --playwright",
     "test:server": "mocha ./test/server/**/*.test.js",

--- a/src/server/rollup.config.js
+++ b/src/server/rollup.config.js
@@ -4,9 +4,9 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { PATHS } from './visual-diff-plugin.js';
 
 export default {
-	input: join(PATHS.VDIFF_ROOT, './report/temp/index.html'),
+	input: join(PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT, './temp/index.html'),
 	output: {
-		dir: join(PATHS.VDIFF_ROOT, 'report')
+		dir: join(PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT)
 	},
 	plugins: [
 		html(),

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -12,6 +12,7 @@ export const PATHS = {
 	FAIL: 'fail',
 	GOLDEN: 'golden',
 	PASS: 'pass',
+	REPORT_ROOT: '.report',
 	VDIFF_ROOT: '.vdiff'
 };
 

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -91,7 +91,7 @@ export function visualDiffReporter({ reportResults = true } = {}) {
 	return {
 		start({ config }) {
 			rootDir = config.rootDir;
-			rmSync(join(rootDir, PATHS.VDIFF_ROOT, 'report'), { force: true, recursive: true });
+			rmSync(join(rootDir, PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT), { force: true, recursive: true });
 		},
 		stop({ sessions }) {
 
@@ -104,7 +104,7 @@ export function visualDiffReporter({ reportResults = true } = {}) {
 			}, '\t');
 
 			const inputDir = join(__dirname, 'report');
-			const reportDir = join(rootDir, PATHS.VDIFF_ROOT, 'report');
+			const reportDir = join(rootDir, PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT);
 			const tempDir = join(reportDir, 'temp');
 
 			mkdirSync(reportDir);

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -185,7 +185,7 @@ export class WTRConfig {
 
 		if (vdiff) {
 			config.reporters ??= [ defaultReporter() ];
-			config.reporters.push(visualDiffReporter());
+			config.reporters.push(visualDiffReporter({ reportResults: !golden }));
 
 			config.plugins ??= [];
 			config.plugins.push(visualDiff({ updateGoldens: golden, runSubset: !!(filter || grep) }));


### PR DESCRIPTION
This renames the `.vdiff/reports/` directory to `.vdiff/.reports`. It also skips building the report when goldens are being generated, since that would put the report in a weird state.