### PR TITLE
refactor tabs and radio stuff out

### DIFF
--- a/src/server/report/radio.js
+++ b/src/server/report/radio.js
@@ -1,0 +1,63 @@
+import { css, html } from 'lit';
+import { getId } from './common.js';
+
+export const RADIO_STYLE = css`
+	.radio-container {
+		border-radius: 5px;
+		display: flex;
+		flex-wrap: nowrap;
+	}
+	.radio-item input[type="radio"] {
+		position: absolute;
+		opacity: 0;
+		pointer-events: none;
+	}
+	.radio-item label {
+		align-items: center;
+		background-color: #ffffff;
+		border-block-end-style: solid;
+		border-block-start-style: solid;
+		border-inline-start-style: solid;
+		border-color: #cdd5dc;
+		border-width: 1px;
+		cursor: pointer;
+		display: flex;
+		gap: 5px;
+		line-height: 24px;
+		padding: 10px;
+		position: relative;
+		user-select: none;
+	}
+	.radio-item:first-child label {
+		border-start-start-radius: 5px;
+		border-end-start-radius: 5px;
+	}
+	.radio-item:last-child label {
+		border-end-end-radius: 5px;
+		border-inline-end-style: solid;
+		border-start-end-radius: 5px;
+	}
+	.radio-item input[type="radio"]:checked + label {
+		background-color: #007bff;
+		color: white;
+	}
+	.radio-item input[type="radio"]:focus-visible + label {
+		z-index: 1;
+		border-color: #007bff;
+		box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #007bff;
+	}
+`;
+
+export function renderRadio(name, selectedValue, onChange, items) {
+	const changeHandler = (e) => onChange(e.target.value);
+	const renderItem = (i) => {
+		const id = getId();
+		return html`
+			<div class="radio-item">
+				<input type="radio" id="${id}" name="${name}" value="${i.value}" @change="${changeHandler}" ?checked="${i.value === selectedValue}">
+				<label for="${id}">${i.icon}${i.label}</label>
+			</div>
+		`;
+	};
+	return html`<div class="radio-container">${items.map(i => renderItem(i))}</div>`;
+}

--- a/src/server/report/tabs.js
+++ b/src/server/report/tabs.js
@@ -1,0 +1,111 @@
+import { css, html, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+
+function onKeyDown(e) {
+	let focusOn;
+	switch (e.key) {
+		case 'ArrowRight':
+			focusOn = e.target.nextElementSibling || e.target.parentNode.firstElementChild;
+			break;
+		case 'ArrowLeft':
+			focusOn = e.target.previousElementSibling || e.target.parentNode.lastElementChild;
+			break;
+		case 'Home':
+			focusOn = e.target.parentNode.firstElementChild;
+			break;
+		case 'End':
+			focusOn = e.target.parentNode.lastElementChild;
+			break;
+	}
+	if (focusOn) focusOn.focus();
+}
+
+export const TAB_STATUS_TYPE = {
+	ERROR: 'error',
+	NORMAL: 'normal'
+};
+
+export const TAB_STYLE = css`
+	[role="tablist"] {
+		align-items: stretch;
+		border-top: 1px solid #cdd5dc;
+		display: flex;
+		flex: 0 0 auto;
+		flex-wrap: nowrap;
+	}
+	[role="tab"] {
+		background: none;
+		border: none;
+		border-right: 1px solid #cdd5dc;
+		cursor: pointer;
+		flex: 1 0 auto;
+		margin: 0;
+		outline: none;
+		padding: 10px 15px;
+		position: relative;
+		user-select: none;
+	}
+	[role="tab"]:last-child {
+		border-right: none;
+	}
+	[role="tab"] > span {
+		display: inline-block;
+		padding: 5px;
+	}
+	[role="tab"]:focus-visible > span {
+		border: 2px solid #007bff;
+		border-radius: 3px;
+		padding: 3px;
+	}
+	[role="tab"]:hover > span {
+		color: #007bff;
+	}
+	.tab-selected-indicator {
+		border-block-start: 4px solid #007bff;
+		border-start-start-radius: 4px;
+		border-start-end-radius: 4px;
+		bottom: 0;
+		position: absolute;
+		width: calc(100% - 30px);
+	}
+`;
+
+export function renderTabButtons(label, tabs, onTabClick) {
+
+	const renderTabButton = (tab, index, onTabClick) => {
+		const clickHandler = () => onTabClick(index);
+		const statusClass = {
+			pass: tab.statusType === TAB_STATUS_TYPE.NORMAL,
+			error: tab.statusType === TAB_STATUS_TYPE.ERROR
+		};
+		return html`
+			<button
+				aria-controls="tabpanel-${tab.id}"
+				aria-selected="${tab.selected ? 'true' : 'false'}"
+				id="tab-${tab.id}"
+				role="tab"
+				tabindex="${tab.selected ? '0' : '-1'}"
+				type="button"
+				@click="${clickHandler}">
+					<span>
+						${tab.label} <span class="${classMap(statusClass)}">(${tab.status})</span>
+					</span>${tab.selected ? html`
+					<div class="tab-selected-indicator"></div>` : nothing}
+			</button>`;
+	};
+
+	return html`
+		<div role="tablist" aria-label="${label}" @keydown="${onKeyDown}">
+			${tabs.map((tab, i) => renderTabButton(tab, i, onTabClick))}
+		</div>
+	`;
+
+}
+
+export function renderTabPanel(tab) {
+	return html`
+		<div id="tabpanel-${tab.id}" role="tabpanel" aria-labelledby="tab-${tab.id}" ?hidden="${!tab.selected}">
+			${tab.content}
+		</div>
+	`;
+}


### PR DESCRIPTION
No visual or functional changes here.

This moves all the tabs and pillbox related rendering and CSS out into separate helper files. This will help reduce the size of `test.js` in preparation for merging it back into `app.js` in part 2 of the refactoring. Because Rollup builds all this together, there's no impact on the report output files -- still just `index.html` and `app.js`.

Background: I originally split these into separate components but in since they don't really need to be reused they're creating overhead to pass stuff down and communicate up.