### PR TITLE
Filter test results to match status

### DIFF
--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -17,7 +17,8 @@ mocha.setup({ // eslint-disable-line no-undef
 async function ScreenshotAndCompare(opts) {
 	const name = this.test.fullTitle();
 	const rect = this.elem.getBoundingClientRect();
-	let result = await executeServerCommand('brightspace-visual-diff-compare', { name, rect, opts });
+	const slowDuration = this.test.slow();
+	let result = await executeServerCommand('brightspace-visual-diff-compare', { name, rect, slowDuration, opts });
 	if (result.resizeRequired) {
 		this.test.timeout(0);
 		result = await executeServerCommand('brightspace-visual-diff-compare-resize', { name });

--- a/src/server/report/app.js
+++ b/src/server/report/app.js
@@ -381,7 +381,7 @@ class App extends LitElement {
 		const tabs = browsers.map((b) => {
 			const numPassed = browserResults.get(b.name);
 			return {
-				content: renderBrowserResults(b, tests, { fullMode: this._fullMode, layout: this._layout, showOverlay: this._overlay }),
+				content: renderBrowserResults(b, tests, { filterStatus: this._filterStatus, fullMode: this._fullMode, layout: this._layout, showOverlay: this._overlay }),
 				label: b.name,
 				id: b.name.toLowerCase(),
 				selected: b.name === selectedBrowser.name,

--- a/src/server/report/common.js
+++ b/src/server/report/common.js
@@ -1,4 +1,38 @@
-import { ICON_FULL, ICON_SPLIT } from './icons.js';
+import { css, html } from 'lit';
+import { ICON_EMPTY, ICON_FULL, ICON_SPLIT } from './icons.js';
+import { classMap } from 'lit/directives/class-map.js';
+
+export const COMMON_STYLE = css`
+	.empty {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+	}
+	.empty > svg {
+		color: #007bff;
+		height: 100px;
+		width: 100px;
+	}
+	.empty > p {
+		color: #6e7477;
+		font-size: 1.1rem;
+		font-weight: bold;
+		margin: 0;
+	}
+	.pass {
+		color: #46a661;
+	}
+	.error {
+		color: #cd2026;
+	}
+	.warning {
+		color: #e87511;
+	}
+	.padding {
+		padding: 20px;
+	}
+`;
 
 export const FILTER_STATUS = {
 	ALL: 'All',
@@ -30,8 +64,37 @@ export const LAYOUTS = {
 	}
 };
 
+export const STATUS_TYPE = {
+	ERROR: 'error',
+	NORMAL: 'normal',
+	WARNING: 'warning'
+};
+
 let id = 0;
 export function getId() {
 	id++;
 	return `id-${id}`;
+}
+
+export function renderEmpty() {
+	return html`
+		<div class="empty padding">
+			${ICON_EMPTY}
+			<p>No tests exist for the selected filters.</p>
+		</div>
+	`;
+}
+
+export function renderStatusText(text, status) {
+	const statusClass = {
+		pass: status === STATUS_TYPE.NORMAL,
+		error: status === STATUS_TYPE.ERROR,
+		warning: status === STATUS_TYPE.WARNING
+	};
+	return html`<span class="${classMap(statusClass)}">${text}</span>`;
+}
+
+export function renderTestStatus(numPassed, numTotal) {
+	const status = numPassed === numTotal ? STATUS_TYPE.NORMAL : STATUS_TYPE.ERROR;
+	return renderStatusText(`(${numPassed}/${numTotal} passed)`, status);
 }

--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -1,5 +1,5 @@
 import { css, html, nothing } from 'lit';
-import { FULL_MODE, LAYOUTS } from './common.js';
+import { FILTER_STATUS, FULL_MODE, LAYOUTS } from './common.js';
 import { ICON_BROWSERS, ICON_TADA } from './icons.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -171,6 +171,10 @@ export function renderBrowserResults(browser, tests, options) {
 			'pass': duration < 500,
 			'warning': duration >= 500 && duration < 1000
 		};
+		if (resultData.passed && options.filterStatus === FILTER_STATUS.FAILED ||
+			!resultData.passed && options.filterStatus === FILTER_STATUS.PASSED) {
+			return nothing;
+		}
 		return html`
 			<div class="result-container">
 				<div class="result-test-name">

--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -153,23 +153,22 @@ function renderResult(resultData, options) {
 }
 
 export function renderBrowserResults(browser, tests, options) {
-	const filteredTests = tests.filter(t => {
+	const results = tests.reduce((acc, t) => {
+
 		const resultData = t.results.find(r => r.name === browser.name);
 		if (resultData.passed && options.filterStatus === FILTER_STATUS.FAILED ||
 			!resultData.passed && options.filterStatus === FILTER_STATUS.PASSED) {
-			return false;
+			return acc;
 		}
-		return true;
-	});
-	const results = filteredTests.map(t => {
-		const resultData = t.results.find(r => r.name === browser.name);
+
 		let status = STATUS_TYPE.NORMAL;
 		if (resultData.duration >= 1000) {
 			status = STATUS_TYPE.ERROR;
 		} else if (resultData.duration >= 500) {
 			status = STATUS_TYPE.WARNING;
 		}
-		return html`
+
+		return acc.push(html`
 			<div class="result-container">
 				<div class="result-test-name">
 					<h3>${t.name}</h3>
@@ -177,8 +176,9 @@ export function renderBrowserResults(browser, tests, options) {
 				</div>
 				${renderResult(resultData, options)}
 			</div>
-		`;
-	});
+		`) && acc;
+
+	}, []);
 	return html`
 		<div class="result-browser padding">
 			${ICON_BROWSERS[browser.name]}
@@ -187,6 +187,6 @@ export function renderBrowserResults(browser, tests, options) {
 				<div>version ${browser.version}</div>
 			</div>
 		</div>
-		${filteredTests.length === 0 ? renderEmpty() : results}
+		${results.length === 0 ? renderEmpty() : results}
 	`;
 }

--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -161,11 +161,11 @@ export function renderBrowserResults(browser, tests, options) {
 			return acc;
 		}
 
-		let status = STATUS_TYPE.NORMAL;
-		if (resultData.duration >= 1000) {
+		let status = STATUS_TYPE.WARNING;
+		if (resultData.duration > resultData.info.slowDuration) {
 			status = STATUS_TYPE.ERROR;
-		} else if (resultData.duration >= 500) {
-			status = STATUS_TYPE.WARNING;
+		} else if (resultData.duration < (resultData.info.slowDuration / 2)) {
+			status = STATUS_TYPE.NORMAL;
 		}
 
 		return acc.push(html`

--- a/src/server/report/tabs.js
+++ b/src/server/report/tabs.js
@@ -1,5 +1,4 @@
 import { css, html, nothing } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
 
 function onKeyDown(e) {
 	let focusOn;
@@ -19,11 +18,6 @@ function onKeyDown(e) {
 	}
 	if (focusOn) focusOn.focus();
 }
-
-export const TAB_STATUS_TYPE = {
-	ERROR: 'error',
-	NORMAL: 'normal'
-};
 
 export const TAB_STYLE = css`
 	[role="tablist"] {
@@ -74,10 +68,6 @@ export function renderTabButtons(label, tabs, onTabClick) {
 
 	const renderTabButton = (tab, index, onTabClick) => {
 		const clickHandler = () => onTabClick(index);
-		const statusClass = {
-			pass: tab.statusType === TAB_STATUS_TYPE.NORMAL,
-			error: tab.statusType === TAB_STATUS_TYPE.ERROR
-		};
 		return html`
 			<button
 				aria-controls="tabpanel-${tab.id}"
@@ -87,9 +77,7 @@ export function renderTabButtons(label, tabs, onTabClick) {
 				tabindex="${tab.selected ? '0' : '-1'}"
 				type="button"
 				@click="${clickHandler}">
-					<span>
-						${tab.label} <span class="${classMap(statusClass)}">(${tab.status})</span>
-					</span>${tab.selected ? html`
+					<span>${tab.label} ${tab.status}</span>${tab.selected ? html`
 					<div class="tab-selected-indicator"></div>` : nothing}
 			</button>`;
 	};

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -123,6 +123,7 @@ function setTestInfo(session, fullTitle, testInfo) {
 	const key = getTestInfoKey(session, fullTitle);
 	if (testInfoMap.has(key)) {
 		const info = testInfoMap.get(key);
+		testInfo.slowDuration = info.slowDuration;
 		if (info.golden || testInfo.golden) {
 			testInfo.golden = { ...info.golden, ...testInfo.golden };
 		}
@@ -193,6 +194,7 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 
 				const rootLength = join(rootDir, PATHS.VDIFF_ROOT).length + 1;
 				setTestInfo(session, payload.name, {
+					slowDuration: payload.slowDuration,
 					golden: {
 						path: goldenFileName.substring(rootLength)
 					},


### PR DESCRIPTION
A few tweaks here based on feedback:

- When viewing an entire file's tests, browser results for those tests should be filtered according to the pass/fail/all status
- When switching between tabs, scroll to the top
- Centralized the rendering of `(x/y passed)`