### PR TITLE
Fix Firefox screenshots

### DIFF
--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -2,7 +2,7 @@ import { chai, expect } from '@open-wc/testing';
 import { executeServerCommand } from '@web/test-runner-commands';
 
 // start loading fonts early
-[...document.fonts].map(font => font.load());
+[...document.fonts].forEach(font => font.load());
 
 let test;
 

--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -1,6 +1,9 @@
 import { chai, expect } from '@open-wc/testing';
 import { executeServerCommand } from '@web/test-runner-commands';
 
+// start loading fonts early
+[...document.fonts].map(font => font.load());
+
 let test;
 
 /* eslint-disable no-undef, no-invalid-this */

--- a/src/server/pause.js
+++ b/src/server/pause.js
@@ -3,6 +3,10 @@ test.pause = new Promise(r => test.start = r);
 
 const controls = `
 	<style>
+		.screenshot * {
+			scrollbar-width: none;
+		}
+
 		.screenshot ::-webkit-scrollbar {
 			display: none;
 		}


### PR DESCRIPTION
Fixes Firefox screenshots by guaranteeing fonts have started loading before the fixture checks if they're ready