### PR TITLE
Fix Windows headed mode import

### DIFF
--- a/src/server/headed-mode-plugin.js
+++ b/src/server/headed-mode-plugin.js
@@ -1,4 +1,4 @@
-import { dirname, join } from 'node:path';
+import { dirname, posix } from 'node:path';
 import { globSync } from 'glob';
 
 export function headedMode({ open, watch, pattern }) {
@@ -9,7 +9,7 @@ export function headedMode({ open, watch, pattern }) {
 		name: 'brightspace-headed-mode',
 		async transform(context) {
 			if ((watch || open) && files.includes(context.path.slice(1))) {
-				const pausePath = join(dirname(import.meta.url), 'pause.js').replace('file:', '');
+				const pausePath = posix.join(dirname(import.meta.url), 'pause.js').replace(/file:(\/c:)?/i, '');
 				return `debugger;\nimport '${pausePath}'\n${context.body}`;
 			}
 		}


### PR DESCRIPTION
The `pausePath` is for an import path, not a filesystem path, so always use POSIX-style forward slash. Also, remove leading `/C:`.

Using an absolute path to the file works because the dev server will resolve and transform it as appropriate for the OS.