### PR TITLE
feat: add support for dark theme

### DIFF
--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -7,6 +7,7 @@ const DEFAULT_LANG = 'en',
 
 let currentLang = undefined,
 	currentRtl = false,
+	currentTheme = undefined,
 	currentViewportHeight = 0,
 	currentViewportWidth = 0,
 	shouldResetMouse = false;
@@ -51,6 +52,16 @@ export async function reset(opts) {
 	if (opts.lang !== currentLang) {
 		document.documentElement.setAttribute('lang', opts.lang);
 		currentLang = opts.lang;
+		awaitNextFrame = true;
+	}
+
+	if (opts.theme !== currentTheme) {
+		if (opts.theme === 'dark') {
+			document.body.setAttribute('data-theme', 'dark');
+		} else {
+			document.body.removeAttribute('data-theme');
+		}
+		currentTheme = opts.theme;
 		awaitNextFrame = true;
 	}
 

--- a/src/server/report/app.js
+++ b/src/server/report/app.js
@@ -49,6 +49,7 @@ class App extends LitElement {
 			border: 1px solid #cdd5dc;
 			padding: 10px;
 			text-align: center;
+			white-space: nowrap;
 		}
 		thead th {
 			background-color: #f5f5f5;
@@ -56,6 +57,8 @@ class App extends LitElement {
 		tbody th {
 			font-weight: normal;
 			text-align: left;
+			width: 100%;
+			white-space: normal;
 		}
 		td.passed {
 			background-color: #efffd9;

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -95,6 +95,9 @@ export class WTRConfig {
 								line-height: 1.4rem;
 								padding: 30px;
 							}
+							body[data-theme="dark"] {
+								background-color: #000000;
+							}
 						</style>
 					</head>
 					<body>

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -157,6 +157,19 @@ describe('fixture', () => {
 			expect(window.innerWidth).to.equal(800);
 		});
 
+		it('should use no theme by default', async() => {
+			await fixture(html`<p>hello</p>`);
+			expect(document.body.hasAttribute('data-theme')).to.be.false;
+		});
+
+		it('should reset theme', async() => {
+			const elem = html`<p>hello</p>`;
+			await fixture(elem, { theme: 'dark' });
+			expect(document.body.getAttribute('data-theme')).to.equal('dark');
+			await fixture(elem);
+			expect(document.body.hasAttribute('data-theme')).to.be.false;
+		});
+
 	});
 
 	describe('waitForElem', () => {

--- a/test/browser/theme.vdiff.js
+++ b/test/browser/theme.vdiff.js
@@ -1,0 +1,44 @@
+import { css, html, LitElement } from 'lit';
+import { defineCE, expect, fixture } from '../../src/browser/index.js';
+
+const themeTag = defineCE(
+	class extends LitElement {
+		static get properties() {
+			return {
+				theme: { reflect: true, type: String }
+			};
+		}
+		static get styles() {
+			return css`
+				:host {
+					border: 1px solid black;
+					display: inline-block;
+					text-align: center;
+					padding: 20px;
+				}
+				:host([theme="dark"]) {
+					border-color: white;
+					color: white;
+				}
+			`;
+		}
+		render() {
+			return html`Theme: ${this.theme}`;
+		}
+	}
+);
+
+describe('theme', () => {
+	[
+		'normal',
+		'dark'
+	].forEach(name => {
+		it(name, async() => {
+			const elem = await fixture(
+				`<${themeTag} theme="${name}"></${themeTag}>`,
+				{ theme: name === 'normal' ? undefined : name }
+			);
+			await expect(elem).to.be.golden();
+		});
+	});
+});


### PR DESCRIPTION
`fixture()` now supports passing `{ theme: 'dark' }`, which results in the page background becoming black. I thought about also setting the foreground colour, but [we don't do that today](https://github.com/BrightspaceUI/core/blob/main/test/styles.css#L20) since dark-mode isn't fully supported anyway.

@dbatiste FYI since I know you've thought a lot about this.