### PR TITLE
expose "slow" CLI parameter and pass-through to Mocha

### DIFF
--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -1,9 +1,9 @@
 import { ConfigLoaderError, readConfig } from '@web/config-loader';
+import { DEFAULT_VDIFF_SLOW, WTRConfig } from '../wtr-config.js';
 import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
 import process from 'node:process';
 import { startTestRunner } from '@web/test-runner';
-import { WTRConfig } from '../wtr-config.js';
 
 async function getTestRunnerOptions(argv = []) {
 
@@ -100,7 +100,7 @@ async function getTestRunnerOptions(argv = []) {
 			name: 'slow',
 			alias: 's',
 			type: Number,
-			description: 'Tests whose duration in milliseconds are at most half of this threshold are "fast" and tests which exceed it are "slow"\n[Default: 75]',
+			description: `Tests whose duration in milliseconds are at most half of this threshold are "fast" and tests which exceed it are "slow"\n[Default: 75 (normal), ${DEFAULT_VDIFF_SLOW} (vdiff)]`,
 			order: 13
 		},
 		{

--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -70,7 +70,7 @@ async function getTestRunnerOptions(argv = []) {
 			name: 'golden',
 			type: Boolean,
 			description: 'Generate new golden screenshots. Ignored unless group is "vdiff".',
-			order: 13
+			order: 14
 		},
 		{
 			name: 'grep',
@@ -83,7 +83,7 @@ async function getTestRunnerOptions(argv = []) {
 			name: 'help',
 			type: Boolean,
 			description: 'Print usage information and exit',
-			order: 14
+			order: 15
 		},
 		{
 			name: 'open',
@@ -95,6 +95,13 @@ async function getTestRunnerOptions(argv = []) {
 			name: 'safari',
 			longAlias: 'webkit',
 			type: Boolean
+		},
+		{
+			name: 'slow',
+			alias: 's',
+			type: Number,
+			description: 'Tests whose duration in milliseconds are at most half of this threshold are "fast" and tests which exceed it are "slow"\n[Default: 75]',
+			order: 13
 		},
 		{
 			name: 'slowmo',

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -14,7 +14,7 @@ const BROWSER_MAP = {
 	safari: 'webkit',
 	webkit: 'webkit'
 };
-const DEFAULT_VDIFF_SLOW = 500;
+export const DEFAULT_VDIFF_SLOW = 500;
 
 export class WTRConfig {
 

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -14,6 +14,7 @@ const BROWSER_MAP = {
 	safari: 'webkit',
 	webkit: 'webkit'
 };
+const DEFAULT_VDIFF_SLOW = 500;
 
 export class WTRConfig {
 
@@ -119,27 +120,35 @@ export class WTRConfig {
 		}).flat();
 	}
 
-	#getMochaConfig(timeoutConfig) {
+	#getMochaConfig(group, slowConfig, timeoutConfig) {
 		const {
 			timeout = timeoutConfig,
 			grep,
 			open,
+			slow = slowConfig,
 			watch
 		} = this.#cliArgs;
 
 		if (typeof timeout !== 'undefined' && typeof timeout !== 'number') throw new TypeError('timeout must be a number');
+		if (typeof slow !== 'undefined' && typeof slow !== 'number') throw new TypeError('slow must be a number');
 
 		const config = {};
 
 		if (timeout) config.timeout = String(timeout);
 		if (open || watch) config.timeout = '0';
 		if (grep) config.grep = grep;
+		if (slow) {
+			config.slow = String(slow);
+		} else if (group === 'vdiff') {
+			config.slow = String(DEFAULT_VDIFF_SLOW);
+		}
 
 		return Object.keys(config).length && { testFramework: { config } };
 	}
 
 	create({
 		pattern = DEFAULT_PATTERN,
+		slow,
 		timeout,
 		...passthroughConfig
 	} = {}) {
@@ -158,7 +167,7 @@ export class WTRConfig {
 
 		const config = {
 			...this.#defaultConfig,
-			...this.#getMochaConfig(timeout),
+			...this.#getMochaConfig(group, slow, timeout),
 			...passthroughConfig
 		};
 

--- a/test/server/cli/test-runner.test.js
+++ b/test/server/cli/test-runner.test.js
@@ -41,7 +41,8 @@ describe('runner.getOptions()', () => {
 			'-c', './test/browser/vdiff.config.js',
 			'-f', 'abc',
 			'-g', 'ghi',
-			'-t', 123]
+			'-t', 123,
+			'-s', 456]
 		);
 		expect(opts.argv).to.deep.equal(['--group', 'test']);
 		expect(opts.config.groups[0]).to.deep.include({
@@ -49,7 +50,7 @@ describe('runner.getOptions()', () => {
 			files: [ 'test/browser/**/+(abc.vdiff.js)' ]
 		});
 		expect(opts.config.testFramework).to.deep.include({
-			config: { timeout: '123', grep: 'ghi' }
+			config: { timeout: '123', grep: 'ghi', slow: '456' }
 		});
 	});
 

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -64,6 +64,47 @@ describe('WTRConfig', () => {
 			});
 		});
 
+		it('should throw for invalid timeout value', () => {
+			expect(() => wtrConfig.create({ timeout: 'never' }))
+				.to.throw(TypeError, 'timeout must be a number');
+		});
+
+		it('should configure testFramework when provided with a slow value', () => {
+			const config = wtrConfig.create({ slow: 1234 });
+			expect(config.testFramework).to.not.be.undefined;
+			expect(config.testFramework.config).to.not.be.undefined;
+			expect(config.testFramework.config.slow).to.equal('1234');
+		});
+
+		it('should set slow from CLI when provided', () => {
+			const wtrConfig = new WTRConfig({ slow: 1234 });
+			const config = wtrConfig.create({ slow: 5678 });
+			expect(config.testFramework.config.slow).to.equal('1234');
+		});
+
+		it('should default slow to a higher value for vdiff group', () => {
+			const wtrConfig = new WTRConfig({ group: 'vdiff' });
+			const config = wtrConfig.create();
+			expect(config.testFramework.config.slow).to.equal('500');
+		});
+
+		it('should set slow from CLI even for vdiff group', () => {
+			const wtrConfig = new WTRConfig({ group: 'vdiff', slow: 1234 });
+			const config = wtrConfig.create();
+			expect(config.testFramework.config.slow).to.equal('1234');
+		});
+
+		it('should set slow from config even for vdiff group', () => {
+			const wtrConfig = new WTRConfig({ group: 'vdiff' });
+			const config = wtrConfig.create({ slow: 5678 });
+			expect(config.testFramework.config.slow).to.equal('5678');
+		});
+
+		it('should throw for invalid slow value', () => {
+			expect(() => wtrConfig.create({ slow: 'fast' }))
+				.to.throw(TypeError, 'slow must be a number');
+		});
+
 		it('should set a common default files pattern', () => {
 			expect(config.groups[0].files).to.deep.equal(['./test/**/*.test.js']);
 		});


### PR DESCRIPTION
Mocha has a concept of a "slow" threshold that it uses to highlight slow/normal/fast tests in reports. It defaults to 75ms. Tests which run in at most half that value are "fast", tests which take longer than that value are "slow" and everything else is "normal".

This exposes `slow` as a CLI argument to `d2l-test-runner` and passes it through to Mocha (similar to `timeout`). It also sets a default value for vdiff tests of `500ms`.