### PR TITLE
make first cell 100% width

### DIFF
--- a/src/server/report/app.js
+++ b/src/server/report/app.js
@@ -49,6 +49,7 @@ class App extends LitElement {
 			border: 1px solid #cdd5dc;
 			padding: 10px;
 			text-align: center;
+			white-space: nowrap;
 		}
 		thead th {
 			background-color: #f5f5f5;
@@ -56,6 +57,8 @@ class App extends LitElement {
 		tbody th {
 			font-weight: normal;
 			text-align: left;
+			width: 100%;
+			white-space: normal;
 		}
 		td.passed {
 			background-color: #efffd9;


### PR DESCRIPTION
Pulling in the unrelated change from #98 now that it's closed. First cell now fills the full width.

<img width="891" alt="Screenshot 2023-07-25 at 1 21 00 PM" src="https://github.com/BrightspaceUI/testing/assets/5491151/beb4a97c-bfc3-4ef1-a45e-4a3f7cf02435">
