### PR TITLE
feat: support configuring mathjax context

### DIFF
--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -2,10 +2,12 @@ import { sendMouse, setViewport } from '@web/test-runner-commands';
 import { nextFrame } from '@open-wc/testing';
 
 const DEFAULT_LANG = 'en',
+	DEFAULT_MATHJAX_RENDER_LATEX = false,
 	DEFAULT_VIEWPORT_HEIGHT = 800,
 	DEFAULT_VIEWPORT_WIDTH = 800;
 
 let currentLang = undefined,
+	currentMathjaxRenderLatex = DEFAULT_MATHJAX_RENDER_LATEX,
 	currentRtl = false,
 	currentViewportHeight = 0,
 	currentViewportWidth = 0,
@@ -19,6 +21,8 @@ export async function reset(opts) {
 
 	opts = opts || {};
 	opts.lang = opts.lang || DEFAULT_LANG;
+	opts.mathjax = opts.mathjax || {};
+	opts.mathjax.renderLatex = (typeof opts.mathjax.renderLatex === 'boolean') ? opts.mathjax.renderLatex : DEFAULT_MATHJAX_RENDER_LATEX;
 	opts.rtl = opts.lang.startsWith('ar') || !!opts.rtl;
 	opts.viewport = opts.viewport || {};
 	opts.viewport.height = opts.viewport.height || DEFAULT_VIEWPORT_HEIGHT;
@@ -59,6 +63,17 @@ export async function reset(opts) {
 		awaitNextFrame = true;
 		currentViewportHeight = opts.viewport.height;
 		currentViewportWidth = opts.viewport.width;
+	}
+
+	if (opts.mathjax.renderLatex !== currentMathjaxRenderLatex) {
+		currentMathjaxRenderLatex = opts.mathjax.renderLatex;
+		if (opts.mathjax.renderLatex === DEFAULT_MATHJAX_RENDER_LATEX) {
+			document.documentElement.removeAttribute('data-mathjax-context');
+		} else {
+			document.documentElement.dataset.mathjaxContext = JSON.stringify({
+				renderLatex: opts.mathjax.renderLatex
+			});
+		}
 	}
 
 	if (awaitNextFrame) {

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -141,6 +141,18 @@ describe('fixture', () => {
 			expect(document.documentElement.getAttribute('lang')).to.equal('en');
 		});
 
+		it('should use specified mathjax latex config', async() => {
+			await fixture(html`<p>hello</p>`, { mathjax: { renderLatex: true } });
+			const config = JSON.parse(document.documentElement.dataset.mathjaxContext);
+			expect(config.renderLatex).to.be.true;
+		});
+
+		it('should should reset mathjax latex config', async() => {
+			await fixture(html`<p>hello</p>`, { mathjax: { renderLatex: true } });
+			await fixture(html`<p>hello</p>`);
+			expect(document.documentElement.hasAttribute('data-mathjax-context')).to.be.false;
+		});
+
 		it('should default viewport size to 800x800', async() => {
 			await fixture(html`<p>hello</p>`);
 			expect(window.innerHeight).to.equal(800);

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -147,7 +147,7 @@ describe('fixture', () => {
 			expect(config.renderLatex).to.be.true;
 		});
 
-		it('should should reset mathjax latex config', async() => {
+		it('should reset mathjax latex config', async() => {
 			await fixture(html`<p>hello</p>`, { mathjax: { renderLatex: true } });
 			await fixture(html`<p>hello</p>`);
 			expect(document.documentElement.hasAttribute('data-mathjax-context')).to.be.false;


### PR DESCRIPTION
This is meant to remove the need for [this plugin](https://github.com/BrightspaceUI/core/tree/main/components/html-block#add-context-automatically-to-demos-and-tests) which includes [this script](https://github.com/BrightspaceUI/core/blob/main/tools/mathjax-test-context.js) in unit and visual-diff tests.

Consumers will be able to enable LaTeX in their tests by passing `{ mathjax: { renderLatex: true } }` as an option to `fixture()`. That'll get reset in between each test. If required, I'm leaving the door open to more mathjax configuration options.