### PR TITLE
Fix golden flag check

### DIFF
--- a/test/browser/vdiff.config.js
+++ b/test/browser/vdiff.config.js
@@ -1,11 +1,11 @@
-import { argv } from 'node:process';
+import process from 'node:process';
 
 function getGoldenFlag() {
 	return {
 		name: 'vdiff-get-golden-flag',
 		async executeCommand({ command }) {
 			if (command !== 'vdiff-get-golden-flag') return;
-			return argv.indexOf('--golden') > -1;
+			return process.argv.indexOf('--golden') > -1;
 		}
 	};
 }


### PR DESCRIPTION
Importing just `argv` makes it a static reference to the original `argv`, so transforming the `golden` command into a `--golden` option on `process.argv` isn't picked up.