### PR TITLE
fix: better handling for small diffs

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -48,10 +48,13 @@ export const RESULT_STYLE = css`
 		line-height: 0;
 		position: relative;
 	}
-	.result-split > .result-part:first-of-type > .result-diff-container {
+	.result-split > .result-part:first-of-type > .result-part-wrapper {
+		text-align: right;
+	}
+	.result-split > .result-part:first-of-type > div > .result-diff-container {
 		border-right: none;
 	}
-	.result-split > .result-part:last-of-type > .result-diff-container {
+	.result-split > .result-part:last-of-type > div> .result-diff-container {
 		border-left: none;
 	}
 	.result-overlay {
@@ -63,6 +66,8 @@ export const RESULT_STYLE = css`
 	.result-part-info {
 		align-items: center;
 		display: flex;
+		gap: 5px;
+		padding: 5px;
 	}
 	.result-part-info-spacer,
 	.result-part-info-size {
@@ -71,11 +76,11 @@ export const RESULT_STYLE = css`
 	.result-part-info-name {
 		flex: 0 0 auto;
 		font-weight: bold;
-		padding: 5px;
 	}
 	.result-part-info-size {
 		color: #90989d;
 		font-size: 0.8rem;
+		white-space: nowrap;
 	}
 	.result-graphic {
 		align-items: center;
@@ -145,7 +150,9 @@ function renderResult(resultData, options) {
 					<div class="result-part-info-name">${label}</div>
 					<div class="result-part-info-size">(${partInfo.width} x ${partInfo.height})</div>
 				</div>
-				<div class="result-diff-container"><img src="../${partInfo.path}" loading="lazy" alt="">${overlay}</div>
+				<div class="result-part-wrapper">
+					<div class="result-diff-container"><img src="../${partInfo.path}" loading="lazy" alt="">${overlay}</div>
+				</div>
 			</div>
 		`;
 	};


### PR DESCRIPTION
Noticed that smaller diffs that caused the report container to be narrow were causing some issues.

Before:
<img width="312" alt="Screenshot 2023-08-09 at 2 54 03 PM" src="https://github.com/BrightspaceUI/testing/assets/5491151/8881c30a-6d03-42c8-a7af-f9e4fbb8f28e">

After:
<img width="299" alt="Screenshot 2023-08-09 at 3 13 39 PM" src="https://github.com/BrightspaceUI/testing/assets/5491151/03c687cf-d853-4a53-88ef-a78f6326dff7">
