### PR TITLE
feat: install playwright dependencies ourselves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,7 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
-        run: |
-          npm ci
-          npx playwright install-deps
+        run: npm ci
       - name: Lint (JavaScript)
         run: npm run lint
       - name: Unit Tests (Browser)

--- a/bin/d2l-test-runner.js
+++ b/bin/d2l-test-runner.js
@@ -29,6 +29,7 @@ if (cli.subcommand === 'vdiff') {
 }
 
 async function runTests() {
+	await runner.install();
 	const options = await runner.getOptions(argv);
 	await runner.start(options);
 }

--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -2,6 +2,7 @@ import { ConfigLoaderError, readConfig } from '@web/config-loader';
 import { DEFAULT_VDIFF_SLOW, WTRConfig } from '../wtr-config.js';
 import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
+import { execSync } from 'node:child_process';
 import process from 'node:process';
 import { startTestRunner } from '@web/test-runner';
 
@@ -196,7 +197,12 @@ async function getTestRunnerOptions(argv = []) {
 	};
 }
 
+function installDeps() {
+	execSync('npx playwright install-deps', { stdio: 'pipe' });
+}
+
 export const runner = {
 	getOptions: getTestRunnerOptions,
+	install: installDeps,
 	start: startTestRunner
 };

--- a/test/bin/d2l-test-runner.test.js
+++ b/test/bin/d2l-test-runner.test.js
@@ -21,10 +21,12 @@ describe('d2l-test-runner', () => {
 		const opts = { my: 'options' };
 		const optionsStub = stub(runner, 'getOptions').returns(opts);
 		const startStub = stub(runner, 'start');
+		const installStub = stub(runner, 'install');
 		await run();
 
 		assert.calledOnceWithExactly(optionsStub, argv);
 		assert.calledOnceWithExactly(startStub, opts);
+		assert.calledOnce(installStub);
 
 		restore();
 	});
@@ -33,6 +35,7 @@ describe('d2l-test-runner', () => {
 		const reportStub = stub(report, 'start');
 		const optionsStub = stub(runner, 'getOptions');
 		const startStub = stub(runner, 'start');
+		const installStub = stub(runner, 'install');
 
 		argv.splice(0, argv.length, 'fake-node', 'fake-test-runner', 'vdiff', 'report');
 		await run();
@@ -40,11 +43,13 @@ describe('d2l-test-runner', () => {
 		assert.calledOnce(reportStub);
 		assert.notCalled(optionsStub);
 		assert.notCalled(startStub);
+		assert.notCalled(installStub);
 	});
 
 	it('generates goldens', async() => {
 		const optionsStub = stub(runner, 'getOptions');
 		const startStub = stub(runner, 'start');
+		const installStub = stub(runner, 'install');
 		const stdoutStub = stub(stdout, 'write');
 
 		argv.splice(0, argv.length, 'fake-node', 'fake-test-runner', 'vdiff', 'golden');
@@ -53,6 +58,7 @@ describe('d2l-test-runner', () => {
 		expect(argv).to.deep.equal(['fake-node', 'fake-test-runner', 'vdiff', '--golden']);
 		assert.calledOnceWithExactly(optionsStub, argv);
 		assert.calledOnce(startStub);
+		assert.calledOnce(installStub);
 		assert.calledOnceWithExactly(stdoutStub, '\nGenerating vdiff goldens...\n');
 	});
 
@@ -60,6 +66,7 @@ describe('d2l-test-runner', () => {
 		const migrateStub = stub(migrate, 'start');
 		const optionsStub = stub(runner, 'getOptions');
 		const startStub = stub(runner, 'start');
+		const installStub = stub(runner, 'install');
 
 		argv.splice(0, argv.length, 'fake-node', 'fake-test-runner', 'vdiff', 'migrate', './test/**/dir');
 		await run();
@@ -67,6 +74,7 @@ describe('d2l-test-runner', () => {
 		assert.calledOnceWithExactly(migrateStub, ['./test/**/dir']);
 		assert.notCalled(optionsStub);
 		assert.notCalled(startStub);
+		assert.notCalled(installStub);
 	});
 
 });


### PR DESCRIPTION
To avoid consumers having to run this in CI anytime they use `d2l-test-runner`, this installs it automatically for them. In testing, it appears to be a no-op if they're already installed.