### PR TITLE
US156332 - Handle passing document.body to get a full page screenshot

### DIFF
--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -27,7 +27,7 @@ async function ScreenshotAndCompare(opts) {
 	}
 
 	const name = this.test.fullTitle();
-	const rect = this.elem.getBoundingClientRect();
+	const rect = this.elem === document.body ? null : this.elem.getBoundingClientRect();
 	const slowDuration = this.test.slow();
 	let result = await executeServerCommand('brightspace-visual-diff-compare', { name, rect, slowDuration, opts });
 	if (result.resizeRequired) {

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -182,18 +182,23 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 				}
 
 				const opts = { margin: DEFAULT_MARGIN, ...payload.opts };
-
-				const page = session.browser.getPage(session.id);
-				await page.screenshot({
+				const screenshotOpts = {
 					animations: 'disabled',
-					clip: {
+					path: updateGoldens ? goldenFileName : screenshotFileName
+				};
+				if (!payload.rect) {
+					screenshotOpts.fullPage = true;
+				} else {
+					screenshotOpts.clip = {
 						x: payload.rect.x - opts.margin,
 						y: payload.rect.y - opts.margin,
 						width: payload.rect.width + (opts.margin * 2),
 						height: payload.rect.height + (opts.margin * 2)
-					},
-					path: updateGoldens ? goldenFileName : screenshotFileName
-				});
+					};
+				}
+
+				const page = session.browser.getPage(session.id);
+				await page.screenshot(screenshotOpts);
 
 				if (updateGoldens) {
 					return { pass: true };

--- a/test/browser/element.vdiff.js
+++ b/test/browser/element.vdiff.js
@@ -53,6 +53,11 @@ describe('element-matches', () => {
 			await expect(elem).to.be.golden();
 		});
 	});
+
+	it('full page', async() => {
+		await fixture(`<${elementTag} text="Visual Difference"></${elementTag}>`, { viewport: { width: 500, height: 500 } });
+		await expect(document.body).to.be.golden();
+	});
 });
 
 describe('element-different', () => {


### PR DESCRIPTION
Visual diff test result looks like this (quoted to help show where it begins and ends lol): 
> ![image](https://github.com/BrightspaceUI/testing/assets/13419300/d06fd0d7-f4c9-4fc0-870b-7b5c005b7d59)
