### PR TITLE
fix: exclude skipped tests from report

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -135,13 +135,6 @@ function renderBrowserInfo(browser) {
 
 function renderResult(resultData, options) {
 
-	if (!resultData.passed && resultData.info === undefined) {
-		return html`
-			<p>An error occurred that prevented a visual-diff snapshot from being taken:</p>
-			<pre>${resultData.error}</pre>
-		`;
-	}
-
 	const renderPart = (label, partInfo, overlay) => {
 		return html`
 			<div class="result-part">

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -78,17 +78,22 @@ function flattenResults(session, browserData, fileData) {
 				});
 			}
 			const testData = fileData.tests.get(testName);
-			if (!t.passed) {
-				browserData.numFailed++;
-				testData.numFailed++;
+
+			// tests missing info were skipped via grep, so exclude them
+			const info = getTestInfo(session, testKey);
+			if (info) {
+				if (!t.passed) {
+					browserData.numFailed++;
+					testData.numFailed++;
+				}
+				testData.results.push({
+					name: browserData.name,
+					duration: t.duration,
+					error: t.error?.message,
+					passed: t.passed,
+					info: info
+				});
 			}
-			testData.results.push({
-				name: browserData.name,
-				duration: t.duration,
-				error: t.error?.message,
-				passed: t.passed,
-				info: getTestInfo(session, testKey)
-			});
 		});
 	}
 


### PR DESCRIPTION
Tests which were skipped (e.g. via `grep`) were showing up in the report but didn't have any "info". This excludes them.