### PR TITLE
fix: exclude skipped tests from report

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -195,11 +195,14 @@ export function renderBrowserResults(browser, tests, options) {
 			return acc;
 		}
 
-		let status = STATUS_TYPE.WARNING;
-		if (resultData.duration > resultData.info.slowDuration) {
-			status = STATUS_TYPE.ERROR;
-		} else if (resultData.duration < (resultData.info.slowDuration / 2)) {
-			status = STATUS_TYPE.NORMAL;
+		let status = STATUS_TYPE.NORMAL;
+		if (resultData.info) {
+			status = STATUS_TYPE.WARNING;
+			if (resultData.duration > resultData.info.slowDuration) {
+				status = STATUS_TYPE.ERROR;
+			} else if (resultData.duration < (resultData.info.slowDuration / 2)) {
+				status = STATUS_TYPE.NORMAL;
+			}
 		}
 
 		return acc.push(html`

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -70,6 +70,11 @@ function flattenResults(session, browserData, fileData) {
 		tests.forEach(t => {
 			const testName = `${prefix}${t.name}`;
 			const testKey = testName.replaceAll(' > ', ' ');
+			const info = getTestInfo(session, testKey);
+
+			// tests missing info but with no error were skipped via grep, so exclude them
+			if (!info && !t.error) return;
+
 			if (!fileData.tests.has(testName)) {
 				fileData.tests.set(testName, {
 					name: testName,
@@ -87,7 +92,7 @@ function flattenResults(session, browserData, fileData) {
 				duration: t.duration,
 				error: t.error?.message,
 				passed: t.passed,
-				info: getTestInfo(session, testKey)
+				info: info
 			});
 		});
 	}


### PR DESCRIPTION
Tests which were skipped (e.g. via grep) were showing up in the report but didn't have any "info". This excludes them.

We differentiate between tests that have no info BUT have an error, which means they failed because an exception was thrown during test execution. We render the error message where the diff would normally be:

<img width="739" alt="Screenshot 2023-08-10 at 5 58 39 PM" src="https://github.com/BrightspaceUI/testing/assets/5491151/d1f0d52a-1a09-43f1-a233-315fac5df523">
