### PR TITLE
Expose oneDefaultPreventedEvent from open-wc/testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ it('should wait for an event', async() => {
 
 Note that the call to `clickElem` is not `await`-ed, since by the time it resolves the event will have already been dispatched.
 
+If you need to prevent the default behaviour of the event in your test, you can use `oneDefaultPreventedEvent`.
+
 #### Waiting for a Lit Element to Update
 
 When using Lit-based components, it's common to create a fixture and then modify some of its properties, which usually requires waiting for those changes to be rendered.

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,5 +1,5 @@
 import './vdiff.js';
 
-export { assert, aTimeout, defineCE, expect, html, nextFrame, oneEvent, oneDefaultPreventedEvent, waitUntil } from '@open-wc/testing';
+export { assert, aTimeout, defineCE, expect, html, nextFrame, oneDefaultPreventedEvent, oneEvent, waitUntil } from '@open-wc/testing';
 export { clickAt, clickElem, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem } from './commands.js';
 export { fixture } from './fixture.js';

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,5 +1,5 @@
 import './vdiff.js';
 
-export { assert, aTimeout, defineCE, expect, html, nextFrame, oneEvent, waitUntil } from '@open-wc/testing';
+export { assert, aTimeout, defineCE, expect, html, nextFrame, oneEvent, oneDefaultPreventedEvent, waitUntil } from '@open-wc/testing';
 export { clickAt, clickElem, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem } from './commands.js';
 export { fixture } from './fixture.js';


### PR DESCRIPTION
I need this in the new dialog unit test I added to test the abort behavior.  I figured it'd be useful to expose this, but if we don't want to I can write my own version for that test.