### PR TITLE
Allow falsy reset options

### DIFF
--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -20,13 +20,13 @@ export function requestMouseReset() {
 export async function reset(opts) {
 
 	opts = opts || {};
-	opts.lang = opts.lang || DEFAULT_LANG;
-	opts.mathjax = opts.mathjax || {};
+	opts.lang = opts.lang ?? DEFAULT_LANG;
+	opts.mathjax = opts.mathjax ?? {};
 	opts.mathjax.renderLatex = (typeof opts.mathjax.renderLatex === 'boolean') ? opts.mathjax.renderLatex : DEFAULT_MATHJAX_RENDER_LATEX;
 	opts.rtl = opts.lang.startsWith('ar') || !!opts.rtl;
-	opts.viewport = opts.viewport || {};
-	opts.viewport.height = opts.viewport.height || DEFAULT_VIEWPORT_HEIGHT;
-	opts.viewport.width = opts.viewport.width || DEFAULT_VIEWPORT_WIDTH;
+	opts.viewport = opts.viewport ?? {};
+	opts.viewport.height = opts.viewport.height ?? DEFAULT_VIEWPORT_HEIGHT;
+	opts.viewport.width = opts.viewport.width ?? DEFAULT_VIEWPORT_WIDTH;
 
 	let awaitNextFrame = false;
 

--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -22,7 +22,7 @@ export async function reset(opts = {}) {
 	const defaultOpts = {
 		lang: DEFAULT_LANG,
 		mathjax: {},
-		rtl: false,
+		rtl: !!opts.lang?.startsWith('ar'),
 		viewport: {
 			height: DEFAULT_VIEWPORT_HEIGHT,
 			width: DEFAULT_VIEWPORT_WIDTH

--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -17,16 +17,21 @@ export function requestMouseReset() {
 	shouldResetMouse = true;
 }
 
-export async function reset(opts) {
+export async function reset(opts = {}) {
 
-	opts = opts || {};
-	opts.lang = opts.lang ?? DEFAULT_LANG;
-	opts.mathjax = opts.mathjax ?? {};
+	const defaultOpts = {
+		lang: DEFAULT_LANG,
+		mathjax: {},
+		rtl: false,
+		viewport: {
+			height: DEFAULT_VIEWPORT_HEIGHT,
+			width: DEFAULT_VIEWPORT_WIDTH
+		}
+	};
+
+	opts = { ...defaultOpts, ...opts };
+	opts.viewport = { ...defaultOpts.viewport, ...opts.viewport };
 	opts.mathjax.renderLatex = (typeof opts.mathjax.renderLatex === 'boolean') ? opts.mathjax.renderLatex : DEFAULT_MATHJAX_RENDER_LATEX;
-	opts.rtl = opts.lang.startsWith('ar') || !!opts.rtl;
-	opts.viewport = opts.viewport ?? {};
-	opts.viewport.height = opts.viewport.height ?? DEFAULT_VIEWPORT_HEIGHT;
-	opts.viewport.width = opts.viewport.width ?? DEFAULT_VIEWPORT_WIDTH;
 
 	let awaitNextFrame = false;
 


### PR DESCRIPTION
This allows consumers to pass falsy reset options but still fall back to default values when the keys are missing. Also prevents mutating the original options object.