### PR TITLE
Use documentLocaleSettings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@brightspace-ui/intl": "^3",
         "@open-wc/testing": "^3",
         "@rollup/plugin-node-resolve": "^15",
         "@web/config-loader": "^0.2",
@@ -403,11 +402,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@brightspace-ui/intl": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.13.2.tgz",
-      "integrity": "sha512-TUb6SZqsi3P6CbREnnwhqGOWu7Svx9JQ1Rw4zRVLj4IozG7kIYu2SfgUrITLYY/moRtiAJTV0wlnYczfBHfG7A=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@brightspace-ui/intl": "^3",
         "@open-wc/testing": "^3",
         "@rollup/plugin-node-resolve": "^15",
         "@web/config-loader": "^0.2",
@@ -402,6 +403,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@brightspace-ui/intl": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.13.2.tgz",
+      "integrity": "sha512-TUb6SZqsi3P6CbREnnwhqGOWu7Svx9JQ1Rw4zRVLj4IozG7kIYu2SfgUrITLYY/moRtiAJTV0wlnYczfBHfG7A=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/intl": "^3",
     "@open-wc/testing": "^3",
     "@rollup/plugin-node-resolve": "^15",
     "@web/config-loader": "^0.2",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@rollup/plugin-node-resolve": "^15",
+    "@brightspace-ui/intl": "^3",
     "@open-wc/testing": "^3",
+    "@rollup/plugin-node-resolve": "^15",
     "@web/config-loader": "^0.2",
     "@web/dev-server": "^0.2",
     "@web/rollup-plugin-html": "^2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@brightspace-ui/intl": "^3",
     "@open-wc/testing": "^3",
     "@rollup/plugin-node-resolve": "^15",
     "@web/config-loader": "^0.2",

--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -1,4 +1,5 @@
 import { sendMouse, setViewport } from '@web/test-runner-commands';
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { nextFrame } from '@open-wc/testing';
 
 const DEFAULT_LANG = 'en',
@@ -6,7 +7,9 @@ const DEFAULT_LANG = 'en',
 	DEFAULT_VIEWPORT_HEIGHT = 800,
 	DEFAULT_VIEWPORT_WIDTH = 800;
 
-let currentLang = undefined,
+const documentLocaleSettings = getDocumentLocaleSettings();
+
+let
 	currentMathjaxRenderLatex = DEFAULT_MATHJAX_RENDER_LATEX,
 	currentRtl = false,
 	currentViewportHeight = 0,
@@ -57,9 +60,9 @@ export async function reset(opts = {}) {
 		currentRtl = opts.rtl;
 	}
 
-	if (opts.lang !== currentLang) {
+	if (opts.lang !== documentLocaleSettings.language) {
 		document.documentElement.setAttribute('lang', opts.lang);
-		currentLang = opts.lang;
+		documentLocaleSettings.language = opts.lang;
 		awaitNextFrame = true;
 	}
 

--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -1,13 +1,10 @@
 import { sendMouse, setViewport } from '@web/test-runner-commands';
-import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { nextFrame } from '@open-wc/testing';
 
 const DEFAULT_LANG = 'en',
 	DEFAULT_MATHJAX_RENDER_LATEX = false,
 	DEFAULT_VIEWPORT_HEIGHT = 800,
 	DEFAULT_VIEWPORT_WIDTH = 800;
-
-const documentLocaleSettings = getDocumentLocaleSettings();
 
 let
 	currentMathjaxRenderLatex = DEFAULT_MATHJAX_RENDER_LATEX,
@@ -60,9 +57,8 @@ export async function reset(opts = {}) {
 		currentRtl = opts.rtl;
 	}
 
-	if (opts.lang !== documentLocaleSettings.language) {
-		document.documentElement.setAttribute('lang', opts.lang);
-		documentLocaleSettings.language = opts.lang;
+	if (document.documentElement.lang !== opts.lang) {
+		document.documentElement.lang = opts.lang;
 		awaitNextFrame = true;
 	}
 

--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -1,10 +1,13 @@
 import { sendMouse, setViewport } from '@web/test-runner-commands';
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { nextFrame } from '@open-wc/testing';
 
 const DEFAULT_LANG = 'en',
 	DEFAULT_MATHJAX_RENDER_LATEX = false,
 	DEFAULT_VIEWPORT_HEIGHT = 800,
 	DEFAULT_VIEWPORT_WIDTH = 800;
+
+const documentLocaleSettings = getDocumentLocaleSettings();
 
 let
 	currentMathjaxRenderLatex = DEFAULT_MATHJAX_RENDER_LATEX,
@@ -57,7 +60,8 @@ export async function reset(opts = {}) {
 		currentRtl = opts.rtl;
 	}
 
-	if (document.documentElement.lang !== opts.lang) {
+	opts.lang ??= '';
+	if (documentLocaleSettings.lamguage !== opts.lang) {
 		document.documentElement.lang = opts.lang;
 		awaitNextFrame = true;
 	}

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -2,13 +2,10 @@
 import { defineCE, expect, fixture, html, waitUntil } from '../../src/browser/index.js';
 import { restore, stub } from 'sinon';
 import { focusElem } from '../../src/browser/commands.js';
-import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { LitElement } from 'lit';
 import { requestMouseReset } from '../../src/browser/reset.js';
 import { sendMouse } from '@web/test-runner-commands';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-
-const documentLocaleSettings = getDocumentLocaleSettings();
 
 const resolves = new Map();
 
@@ -135,16 +132,13 @@ describe('fixture', () => {
 		it('should default language to EN', async() => {
 			await fixture(html`<p>hello</p>`);
 			expect(document.documentElement.getAttribute('lang')).to.equal('en');
-			expect(documentLocaleSettings.language).to.equal('en');
 		});
 
 		it('should reset language to EN', async() => {
 			await fixture(html`<p>bonjour</p>`, { lang: 'fr' });
 			expect(document.documentElement.getAttribute('lang')).to.equal('fr');
-			expect(documentLocaleSettings.language).to.equal('fr');
 			await fixture(html`<p>hello</p>`);
 			expect(document.documentElement.getAttribute('lang')).to.equal('en');
-			expect(documentLocaleSettings.language).to.equal('en');
 		});
 
 		it('should use specified mathjax latex config', async() => {

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -2,10 +2,13 @@
 import { defineCE, expect, fixture, html, waitUntil } from '../../src/browser/index.js';
 import { restore, stub } from 'sinon';
 import { focusElem } from '../../src/browser/commands.js';
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { LitElement } from 'lit';
 import { requestMouseReset } from '../../src/browser/reset.js';
 import { sendMouse } from '@web/test-runner-commands';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+
+const documentLocaleSettings = getDocumentLocaleSettings();
 
 const resolves = new Map();
 
@@ -132,13 +135,16 @@ describe('fixture', () => {
 		it('should default language to EN', async() => {
 			await fixture(html`<p>hello</p>`);
 			expect(document.documentElement.getAttribute('lang')).to.equal('en');
+			expect(documentLocaleSettings.language).to.equal('en');
 		});
 
 		it('should reset language to EN', async() => {
 			await fixture(html`<p>bonjour</p>`, { lang: 'fr' });
 			expect(document.documentElement.getAttribute('lang')).to.equal('fr');
+			expect(documentLocaleSettings.language).to.equal('fr');
 			await fixture(html`<p>hello</p>`);
 			expect(document.documentElement.getAttribute('lang')).to.equal('en');
+			expect(documentLocaleSettings.language).to.equal('en');
 		});
 
 		it('should use specified mathjax latex config', async() => {


### PR DESCRIPTION
Lots of things are listening for changes to the common `DocumentLocaleSettings` instance, so use that instead of local `currentLang`, which can get out of sync of the lang is changed before the next `reset`.

`d2l-localize-behavior` blew up in all kinds of weird ways when I switched to the new `fixture` without this.