### PR TITLE
US157225 - Handle when styles are placed on the host that we want included in the rect

### DIFF
--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -23,7 +23,7 @@ function findTargets(elem) {
 	if (!elem.shadowRoot) return [elem];
 	const nestedTargets = elem.shadowRoot.querySelectorAll('.vdiff-target');
 	if (nestedTargets.length === 0) return [elem];
-	return Array.from(nestedTargets).reduce((acc, target) => [...acc, ...findTargets(target)], []);
+	return Array.from(nestedTargets).reduce((acc, target) => [...acc, ...findTargets(target)], [elem]);
 }
 
 function findLargestRect(elems) {


### PR DESCRIPTION
I thought I could get away without this (basically _either_ you use `vdiff-target` for everything you need in your shadow DOM, or for nothing and the whole element will be used). But then I immediately ran into a problem with `d2l-count-badge-icon`, which adds a bunch of padding to the `host`. So we now always consider the custom element size in the `rect` calculation.