### PR TITLE
US157225 - Ignore base element's rect if it has no width and/or height

### DIFF
--- a/src/browser/vdiff.js
+++ b/src/browser/vdiff.js
@@ -32,12 +32,14 @@ function findLargestRect(elems) {
 		const targets = findTargets(elem);
 		targets.forEach(target => {
 			const targetRect = target.getBoundingClientRect();
-			largestRect = {
-				left: Math.floor(Math.min(largestRect.left, targetRect.left)),
-				top: Math.floor(Math.min(largestRect.top, targetRect.top)),
-				right: Math.ceil(Math.max(largestRect.right, targetRect.right)),
-				bottom: Math.ceil(Math.max(largestRect.bottom, targetRect.bottom))
-			};
+			if (targetRect.width !== 0 && targetRect.height !== 0) {
+				largestRect = {
+					left: Math.floor(Math.min(largestRect.left, targetRect.left)),
+					top: Math.floor(Math.min(largestRect.top, targetRect.top)),
+					right: Math.ceil(Math.max(largestRect.right, targetRect.right)),
+					bottom: Math.ceil(Math.max(largestRect.bottom, targetRect.bottom))
+				};
+			}
 		});
 	});
 


### PR DESCRIPTION
If an element has either no height or no width, we don't need to care about it's position. It will have an inner `vdiff-target` telling us what to actually use. But if the element has both a width and a height, then it _and_ its inner `vdiff-target`s will be considered in the calculation.