### PR TITLE
feat: surface the number of pixels that are different in the report

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -99,6 +99,7 @@ export const RESULT_STYLE = css`
 	.result-test-name {
 		align-items: center;
 		display: flex;
+		gap: 10px;
 		padding-bottom: 10px;
 	}
 	.result-test-name > h3 {
@@ -205,10 +206,21 @@ export function renderBrowserResults(browser, tests, options) {
 			}
 		}
 
+		let pixelsDiff = nothing;
+		if (resultData.info?.pixelsDiff > 0) {
+			const pixelsStatus = (resultData.info?.pixelsDiff) < 10 ? STATUS_TYPE.WARNING : STATUS_TYPE.ERROR;
+			pixelsDiff = html`
+				<div class="result-pixels-diff">
+					${renderStatusText(`${resultData.info.pixelsDiff.toLocaleString()}px`, pixelsStatus)}
+				</div>
+			`;
+		}
+
 		return acc.push(html`
 			<div class="item-container">
 				<div class="result-test-name">
 					<h3>${t.name}</h3>
+					${pixelsDiff}
 					<div class="result-duration">${renderStatusText(`${resultData.duration}ms`, status)}</div>
 				</div>
 				${renderResult(resultData, options)}

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -246,7 +246,8 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 							diff: `${screenshotFile.substring(rootLength)}-diff.png`,
 							new: {
 								path: `${screenshotFile.substring(rootLength)}.png`
-							}
+							},
+							pixelsDiff
 						});
 						await writeFile(`${screenshotFile}-diff.png`, PNG.sync.write(diff));
 						return { pass: false, message: `Image does not match golden. ${pixelsDiff} pixels are different.` };
@@ -297,7 +298,8 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 					},
 					new: {
 						path: `${screenshotFile.substring(rootLength)}-resized-screenshot.png`
-					}
+					},
+					pixelsDiff
 				});
 
 				return { pass: false, message: `Images are not the same size. When resized, ${pixelsDiff} pixels are different.` };


### PR DESCRIPTION
While migrating core's tests, when you get them "perfect" there are still a few pixels off. I found myself hiding/showing the overlay to help determine if I was close or not. Just displaying the number of pixels that are different like in the console output would be helpful!

That's what this does -- top right corner next to the duration:

<img width="864" alt="Screenshot 2023-09-11 at 10 56 25 AM" src="https://github.com/BrightspaceUI/testing/assets/5491151/01f3c257-4ec2-4a37-a341-db44ffbe39f2">

