### PR TITLE
Support fullscreen fixture option

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,16 @@ To capture the entire viewport, pass `document` as the target element to the ass
 await expect(document).to.be.golden();
 ```
 
+#### Rendering Fullscreen Fixtures
+
+To render a fullscreen fixture that fills the viewport, pass a `fullscreen` option to `fixture()`:
+
+```javascript
+  const elem = await fixture(html`<fullscreen-elem></fullscreen-elem>`, {
+    fullscreen: true
+  });
+```
+
 #### Including Other Elements
 
 Elements using `absolute` or `fixed` positioning (like dropdowns or tooltips) may overflow the target element's capture area. To include them, apply the `vdiff-include` CSS class.

--- a/src/browser/fixture.js
+++ b/src/browser/fixture.js
@@ -49,7 +49,11 @@ async function waitForElem(elem, awaitLoadingComplete = true) {
 
 export async function fixture(element, opts = {}) {
 	await Promise.all([reset(opts), document.fonts.ready]);
-	const elem = await wcFixture(element);
+
+	const parentNode = document.createElement('div');
+	parentNode.setAttribute('id', 'd2l-test-fixture-container');
+
+	const elem = await wcFixture(element, { parentNode });
 	await waitForElem(elem, opts.awaitLoadingComplete);
 
 	await pause();

--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -2,7 +2,8 @@ import { sendMouse, setViewport } from '@web/test-runner-commands';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { nextFrame } from '@open-wc/testing';
 
-const DEFAULT_LANG = 'en',
+const DEFAULT_FULLSCREEN = false,
+	DEFAULT_LANG = 'en',
 	DEFAULT_MATHJAX_RENDER_LATEX = false,
 	DEFAULT_VIEWPORT_HEIGHT = 800,
 	DEFAULT_VIEWPORT_WIDTH = 800;
@@ -10,6 +11,7 @@ const DEFAULT_LANG = 'en',
 const documentLocaleSettings = getDocumentLocaleSettings();
 
 let
+	currentFullscreen = false,
 	currentMathjaxRenderLatex = DEFAULT_MATHJAX_RENDER_LATEX,
 	currentRtl = false,
 	currentViewportHeight = 0,
@@ -29,7 +31,8 @@ export async function reset(opts = {}) {
 		viewport: {
 			height: DEFAULT_VIEWPORT_HEIGHT,
 			width: DEFAULT_VIEWPORT_WIDTH
-		}
+		},
+		fullscreen: DEFAULT_FULLSCREEN
 	};
 
 	opts = { ...defaultOpts, ...opts };
@@ -39,6 +42,17 @@ export async function reset(opts = {}) {
 	let awaitNextFrame = false;
 
 	window.scroll(0, 0);
+
+	if (opts.fullscreen !== currentFullscreen) {
+		if (opts.fullscreen) {
+			document.body.classList.add('fullscreen');
+		}
+		else {
+			document.body.classList.remove('fullscreen');
+		}
+		awaitNextFrame = true;
+		currentFullscreen = opts.fullscreen;
+	}
 
 	if (shouldResetMouse) {
 		shouldResetMouse = false;

--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -202,7 +202,7 @@ async function getTestRunnerOptions(argv = []) {
 }
 
 function installDeps() {
-	//execSync('npx playwright install-deps', { stdio: 'pipe' });
+	execSync('npx playwright install-deps', { stdio: 'pipe' });
 }
 
 export const runner = {

--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -202,7 +202,7 @@ async function getTestRunnerOptions(argv = []) {
 }
 
 function installDeps() {
-	execSync('npx playwright install-deps', { stdio: 'pipe' });
+	//execSync('npx playwright install-deps', { stdio: 'pipe' });
 }
 
 export const runner = {

--- a/src/server/pause.js
+++ b/src/server/pause.js
@@ -15,7 +15,11 @@ const controls = `
 			display: none !important;
 		}
 		body {
-			margin-top: 70px;
+			margin-top: 76px;
+		}
+
+		:not(.screenshot) body.fullscreen > #d2l-test-fixture-container {
+			top: 76px;
 		}
 
 		.screenshot body {

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -96,7 +96,7 @@ export class WTRConfig {
 								line-height: 1.4rem;
 								padding: 30px;
 							}
-							body.fullscreen > div:first-of-type {
+							body.fullscreen > #d2l-test-fixture-container {
 								position: absolute;
 								inset: 0;
 							}

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -96,6 +96,10 @@ export class WTRConfig {
 								line-height: 1.4rem;
 								padding: 30px;
 							}
+							body.fullscreen > div:first-of-type {
+								position: absolute;
+								inset: 0;
+							}
 						</style>
 					</head>
 					<body>


### PR DESCRIPTION
Adds a `fullscreen` option to make the fixture container fill the viewport so that screenshots are the expected size.

This should also hopefully reduce instances of goldens changing size during migration, requiring manipulation of the viewport, as was [the case for annotations](https://github.com/Brightspace/annotations/pull/4/files#diff-f954cf98e10ebe7c7ad0fac0cb2cc6f3cd62d19c85d6b85205998693bacd26d8R35).