### PR TITLE
fix: increasing timeout to 5 minutes for vdiff tests

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -187,6 +187,8 @@ export class WTRConfig {
 				files: this.#pattern
 			});
 		} else if (group === 'vdiff') {
+			config.testsFinishTimeout = 5 * 60 * 1000;
+
 			config.reporters ??= [ defaultReporter() ];
 			config.reporters.push(visualDiffReporter({ updateGoldens: golden }));
 


### PR DESCRIPTION
This gives each vdiff test file 5 minutes to run instead of the default of 2. This has nothing to do with the total run time, just each file. If this ends up not being enough for the core table tests, we can go higher.