### PR TITLE
Install playwright browsers manually to support playwright@1.38.0

### DIFF
--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -202,7 +202,7 @@ async function getTestRunnerOptions(argv = []) {
 }
 
 function installDeps() {
-	execSync('npx playwright install-deps', { stdio: 'pipe' });
+	execSync('npx playwright install --with-deps', { stdio: 'pipe' });
 }
 
 export const runner = {


### PR DESCRIPTION
Starting with [Playwright v1.38.0](https://github.com/microsoft/playwright/releases/tag/v1.38.0) browsers are no longer downloaded automatically, so we need to do so manually.

