### PR TITLE
fix: export `elementUpdated`

### DIFF
--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,5 +1,5 @@
 import './vdiff.js';
 
-export { assert, aTimeout, defineCE, expect, html, nextFrame, oneDefaultPreventedEvent, oneEvent, waitUntil } from '@open-wc/testing';
+export { assert, aTimeout, defineCE, elementUpdated, expect, html, nextFrame, oneDefaultPreventedEvent, oneEvent, waitUntil } from '@open-wc/testing';
 export { clickAt, clickElem, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem } from './commands.js';
 export { fixture } from './fixture.js';


### PR DESCRIPTION
Was looking at switching outcomes over to this new framework and noticed that [`elementUpdated`](https://open-wc.org/docs/testing/helpers/#elementupdated) isn't exported from the `@open-wc/testing` package. Adding it so it's available unless there's a reason it was left out.

Source: https://github.com/open-wc/open-wc/blob/master/packages/testing-helpers/src/elementUpdated.js

Looks like it basically does what you describe [here](https://github.com/BrightspaceUI/testing#waiting-for-a-lit-element-to-update) just covering more cases.

