### PR TITLE
feat: set the page's timezone

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -14,6 +14,7 @@ const BROWSER_MAP = {
 	safari: 'webkit',
 	webkit: 'webkit'
 };
+const TIMEZONE = '{&quot;name&quot;:&quot;Canada - Toronto&quot;,&quot;identifier&quot;:&quot;America/Toronto&quot;}';
 export const DEFAULT_VDIFF_SLOW = 500;
 
 export class WTRConfig {
@@ -34,7 +35,7 @@ export class WTRConfig {
 			nodeResolve: true,
 			testRunnerHtml: testFramework =>
 				`<!DOCTYPE html>
-				<html lang="en">
+				<html lang="en" data-timezone='${TIMEZONE}'>
 					<body>
 						<script>
 							window.addEventListener('error', (err) => {
@@ -66,7 +67,7 @@ export class WTRConfig {
 			browsers: ['chrome'],
 			testRunnerHtml: testFramework =>
 				`<!DOCTYPE html>
-				<html lang="en">
+				<html lang="en" data-timezone='${TIMEZONE}'>
 					<head>
 						<link rel="preload" href="https://s.brightspace.com/lib/fonts/0.5.0/assets/Lato-400.woff2" as="font" type="font/woff2" crossorigin>
 						<link rel="preload" href="https://s.brightspace.com/lib/fonts/0.5.0/assets/Lato-700.woff2" as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
For better or worse, our Intl library pulls the timezone name off the HTML document and some tests like the time input ones are relying on it being there.

If we need to make this configurable in the future via `fixture`, we can.