### PR TITLE
US158410 - Handle initial vdiff failure more gracefully

### DIFF
--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -129,7 +129,7 @@ export function visualDiffReporter({ updateGoldens } = {}) {
 			const reportDir = join(rootDir, PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT);
 			const tempDir = join(reportDir, 'temp');
 
-			mkdirSync(reportDir);
+			mkdirSync(reportDir, { recursive: true });
 
 			cpSync(inputDir, tempDir, { force: true, recursive: true });
 			writeFileSync(join(tempDir, 'data.js'), `export default ${json};`);


### PR DESCRIPTION
If you run the `vdiff` command for the first time but something goes wrong (for example, the `beforeEach` times out) such that no goldens are created, the `.vdiff` folder will not exist. That results in this error message:
```
Error: ENOENT: no such file or directory, mkdir '<path>\.vdiff\.report'
```
It causes confusion with what the actual error is, so we now handle this and create an empty report.