### PR TITLE
fix: disable Chrome sandbox

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -240,6 +240,7 @@ export class WTRConfig {
 			product: b,
 			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor: 2, reducedMotion: 'reduce' }),
 			launchOptions: {
+				args: b === 'chromium' ? ['--no-sandbox', '--disable-setuid-sandbox'] : undefined,
 				headless: !this.#cliArgs.open,
 				devtools: false,
 				slowMo: this.#cliArgs.slowmo || 0


### PR DESCRIPTION
In an attempt to resolve the 30 second timeouts we're seeing in self-hosted runners, we're going to experiment with disabling the sandbox. It's hard to tell if this is even passing the right thing along to Chrome, but from what I can tell this is how to do it.

Once this releases, I'll try it out in `lms-core` a bunch of times. If we're still getting timeouts, I'll revert.