### PR TITLE
Support implicit groups and default group files

### DIFF
--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -133,7 +133,7 @@ async function getTestRunnerOptions(argv = []) {
 			},
 			{
 				header: 'Usage',
-				content: 'd2l-test-runner [options]\nd2l-test-runner <command> [options]\n',
+				content: 'd2l-test-runner [options]\nd2l-test-runner <group> [options]\nd2l-test-runner <command> [options]\n',
 			},
 			{
 				header: 'Options',

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -187,6 +187,11 @@ export class WTRConfig {
 
 		if (!['test', 'vdiff', ...passthroughGroupNames].includes(group)) {
 			config.groups.push({ name: group, files: this.#pattern });
+		} else {
+			const groupConfig = config.groups.find(g => g.name === group);
+			if (groupConfig) {
+				groupConfig.files = this.#pattern;
+			}
 		}
 
 		if (filter) {

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -174,10 +174,6 @@ export class WTRConfig {
 		const { files, filter, golden, grep, group, open, watch } = this.#cliArgs;
 		const passthroughGroupNames = passthroughConfig.groups?.map(g => g.name) ?? [];
 
-		if (!['test', 'vdiff', ...passthroughGroupNames].includes(group)) {
-			return {}; // allow wtr to error
-		}
-
 		delete passthroughConfig.browsers;
 
 		if (typeof pattern !== 'function') throw new TypeError('pattern must be a function');
@@ -188,6 +184,10 @@ export class WTRConfig {
 			...this.#getMochaConfig(group, slow, timeout),
 			...passthroughConfig
 		};
+
+		if (!['test', 'vdiff', ...passthroughGroupNames].includes(group)) {
+			config.groups.push({ name: group, files: this.#pattern });
+		}
 
 		if (filter) {
 			config.groups.forEach(group => {

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -11,12 +11,6 @@ describe('WTRConfig', () => {
 			config = wtrConfig.create();
 		});
 
-		it('should return an empty object given invalid group', () => {
-			const wtrConfig = new WTRConfig({ group: 'default' });
-			const config = wtrConfig.create();
-			expect(config).to.deep.equal({});
-		});
-
 		it('should remove browsers passthrough config', () => {
 			const config = wtrConfig.create({ browsers: [ 1, 2, 3 ] });
 			expect(config).to.be.an('object');
@@ -29,6 +23,17 @@ describe('WTRConfig', () => {
 			const group = config.groups[0];
 			expect(config.groups).to.be.an('array').that.has.length(1);
 			expect(group.name).to.equal('a-group');
+			expect(group.browsers).to.be.an('array').that.has.length(3);
+			expect(group.browsers.filter(b => b.name === 'Chromium')).to.have.length(1);
+			group.browsers.forEach(b => expect(b.constructor.name).to.equal('PlaywrightLauncher'));
+		});
+
+		it('should create a valid group when requested from CLI', () => {
+			const wtrConfig = new WTRConfig({ group: 'implicit-group' });
+			const config = wtrConfig.create();
+			const group = config.groups[0];
+			expect(config.groups).to.be.an('array').that.has.length(1);
+			expect(group.name).to.equal('implicit-group');
 			expect(group.browsers).to.be.an('array').that.has.length(3);
 			expect(group.browsers.filter(b => b.name === 'Chromium')).to.have.length(1);
 			group.browsers.forEach(b => expect(b.constructor.name).to.equal('PlaywrightLauncher'));

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -39,6 +39,15 @@ describe('WTRConfig', () => {
 			group.browsers.forEach(b => expect(b.constructor.name).to.equal('PlaywrightLauncher'));
 		});
 
+		it('should add missing files to group config', () => {
+			const wtrConfig = new WTRConfig({ group: 'a-group' });
+			const config = wtrConfig.create({ groups: [{ name: 'a-group' }] });
+			const group = config.groups[0];
+			expect(config.groups).to.be.an('array').that.has.length(1);
+			expect(group.name).to.equal('a-group');
+			expect(group.files).to.deep.equal(['./test/**/*.a-group.js']);
+		});
+
 		it('should enable nodeResolve', () => {
 			expect(config.nodeResolve).to.be.true;
 		});

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -34,9 +34,8 @@ describe('WTRConfig', () => {
 			const group = config.groups[0];
 			expect(config.groups).to.be.an('array').that.has.length(1);
 			expect(group.name).to.equal('implicit-group');
+			expect(group.files).to.deep.equal(['./test/**/*.implicit-group.js']);
 			expect(group.browsers).to.be.an('array').that.has.length(3);
-			expect(group.browsers.filter(b => b.name === 'Chromium')).to.have.length(1);
-			group.browsers.forEach(b => expect(b.constructor.name).to.equal('PlaywrightLauncher'));
 		});
 
 		it('should add missing files to group config', () => {


### PR DESCRIPTION
Groups shouldn't need to be explicitly declared in a config file to run test files with a matching `type`. Similarly, groups that are declared in a config file shouldn't need to explicitly declare their `files` config, instead using the `pattern` by default.