### PR TITLE
Always exclude node_modules from files, improve filtering

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -54,7 +54,7 @@ export class WTRConfig {
 	}
 
 	get #pattern() {
-		const files = [ this.#cliArgs.files || this.pattern(this.#cliArgs.group), '!**/node_modules/**/*' ];
+		const files = [ this.#cliArgs.files || this.pattern(this.#cliArgs.group), '!**/node_modules/**/*' ].flat();
 
 		if (this.#cliArgs.filter) {
 			return this.#filterFiles(files);
@@ -124,10 +124,9 @@ export class WTRConfig {
 	}
 
 	#filterFiles(files) {
-		const flatFiles = files.flat();
 		return this.#cliArgs.filter.map(filterStr => {
 			// replace everything after the last forward slash
-			return flatFiles
+			return files
 				.filter(f => !f.startsWith('!')) // don't filter exclusions
 				.map(f => f.replace(/[^/]*$/, fileGlob => {
 					// create a new glob for each wildcard
@@ -140,7 +139,7 @@ export class WTRConfig {
 				}));
 		})
 			.flat()
-			.concat(flatFiles.filter(f => f.startsWith('!')));
+			.concat(files.filter(f => f.startsWith('!')));
 	}
 
 	#getMochaConfig(group, slowConfig, timeoutConfig) {

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -124,9 +124,10 @@ export class WTRConfig {
 	}
 
 	#filterFiles(files) {
+		const flatFiles = files.flat();
 		return this.#cliArgs.filter.map(filterStr => {
 			// replace everything after the last forward slash
-			return files
+			return flatFiles
 				.filter(f => !f.startsWith('!')) // don't filter exclusions
 				.map(f => f.replace(/[^/]*$/, fileGlob => {
 					// create a new glob for each wildcard
@@ -139,7 +140,7 @@ export class WTRConfig {
 				}));
 		})
 			.flat()
-			.concat(files.filter(f => f.startsWith('!')));
+			.concat(flatFiles.filter(f => f.startsWith('!')));
 	}
 
 	#getMochaConfig(group, slowConfig, timeoutConfig) {

--- a/test/server/cli/test-runner.test.js
+++ b/test/server/cli/test-runner.test.js
@@ -14,7 +14,7 @@ describe('runner.getOptions()', () => {
 		expect(opts.config.groups).to.be.an('array').with.length(1);
 		expect(opts.config.groups[0]).to.deep.include({
 			name: 'test',
-			files: ['./test/**/*.test.js']
+			files: [ './test/**/*.test.js', '!**/node_modules/**/*' ]
 		});
 	});
 
@@ -47,7 +47,7 @@ describe('runner.getOptions()', () => {
 		expect(opts.argv).to.deep.equal(['--group', 'test']);
 		expect(opts.config.groups[0]).to.deep.include({
 			name: 'test',
-			files: [ 'test/browser/**/+(abc.vdiff.js)' ]
+			files: [ 'test/browser/**/+(abc.vdiff.js)', '!**/node_modules/**/*' ]
 		});
 		expect(opts.config.testFramework).to.deep.include({
 			config: { timeout: '123', grep: 'ghi', slow: '456' }

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -34,7 +34,7 @@ describe('WTRConfig', () => {
 			const group = config.groups[0];
 			expect(config.groups).to.be.an('array').that.has.length(1);
 			expect(group.name).to.equal('implicit-group');
-			expect(group.files).to.deep.equal(['./test/**/*.implicit-group.js']);
+			expect(group.files).to.include.members(['./test/**/*.implicit-group.js']);
 			expect(group.browsers).to.be.an('array').that.has.length(3);
 		});
 
@@ -44,7 +44,7 @@ describe('WTRConfig', () => {
 			const group = config.groups[0];
 			expect(config.groups).to.be.an('array').that.has.length(1);
 			expect(group.name).to.equal('a-group');
-			expect(group.files).to.deep.equal(['./test/**/*.a-group.js']);
+			expect(group.files).to.include.members(['./test/**/*.a-group.js']);
 		});
 
 		it('should enable nodeResolve', () => {
@@ -119,12 +119,12 @@ describe('WTRConfig', () => {
 		});
 
 		it('should set a common default files pattern', () => {
-			expect(config.groups[0].files).to.deep.equal(['./test/**/*.test.js']);
+			expect(config.groups[0].files).to.deep.equal([ './test/**/*.test.js', '!**/node_modules/**/*' ]);
 		});
 
 		it('should run a given pattern function to set files', () => {
 			const config = wtrConfig.create({ pattern: type => `./a/b.${type}.js` });
-			expect(config.groups[0].files).to.deep.equal(['./a/b.test.js']);
+			expect(config.groups[0].files).to.include.members(['./a/b.test.js']);
 		});
 
 		it('should create a "test" group by default', () => {
@@ -150,8 +150,8 @@ describe('WTRConfig', () => {
 			const wtrConfig = new WTRConfig({ filter: ['subset', 'subset*'] });
 			const config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.*` });
 			expect(config.files).to.be.undefined;
-			expect(config.groups[0].files).to.have.length(2);
-			expect(config.groups[0].files).to.have.members(['./test/**/*/+(subset.test.*|*.test.subset)', './test/**/*/+(subset*.test.*|*.test.subset*)']);
+			expect(config.groups[0].files).to.have.length(3);
+			expect(config.groups[0].files).to.have.members(['./test/**/*/+(subset.test.*|*.test.subset)', './test/**/*/+(subset*.test.*|*.test.subset*)', '!**/node_modules/**/*']);
 		});
 
 		it('should add --grep value to testFramework config', () => {

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -154,6 +154,13 @@ describe('WTRConfig', () => {
 			expect(config.groups[0].files).to.have.members(['./test/**/*/+(subset.test.*|*.test.subset)', './test/**/*/+(subset*.test.*|*.test.subset*)', '!**/node_modules/**/*']);
 		});
 
+		it('should never filter excluded files', () => {
+			const wtrConfig = new WTRConfig({ filter: ['subset'], files: ['./used/*', '!no-no/*'] });
+			const config = wtrConfig.create({ pattern: () => './not-used/*' });
+			expect(config.groups[0].files).to.have.length(3);
+			expect(config.groups[0].files).to.have.members(['./used/+(subset)', '!no-no/*', '!**/node_modules/**/*']);
+		});
+
 		it('should add --grep value to testFramework config', () => {
 			const wtrConfig = new WTRConfig({ grep: 'subset|subset2' });
 			const config = wtrConfig.create();


### PR DESCRIPTION
- Never run tests in `node_modules`
- Never filter `files` exclusion items
- Fixes filtering multiple `filters` from CLI (e.g. `--filter a b`)