### PR TITLE
fix: increase browserStartTimeout

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -40,6 +40,7 @@ export class WTRConfig {
 
 	get #defaultConfig() {
 		return {
+			browserStartTimeout: 60 * 1000,
 			groups: [],
 			nodeResolve: true,
 			testRunnerHtml: testFramework =>


### PR DESCRIPTION
There's some circumstantial evidence that doubling this from 30 seconds to 1 minute may "solve" the issue we're seeing with timeouts due to slow browser startup. Presumably the runs will still be super slow, but this may avoid having them fail completely.