### PR TITLE
fix: Fix report showing incorrect error message

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -175,7 +175,7 @@ function renderResult(resultData, options) {
 		let newPart;
 		if (resultData.passed) {
 			newPart = html`<div class="result-graphic padding">${ICON_TADA}<p>Hooray! No changes here.</p></div>`;
-		} else if (resultData.info.pixelsDiff === 0) {
+		} else if (!resultData.info.diff && resultData.info.pixelsDiff === 0) {
 			newPart = html`<div class="result-graphic padding">${ICON_BYTES}
 				<p>No pixels have changed, but the byte size is different.</p>
 				<p class="details">


### PR DESCRIPTION
Found this issue with all the vdiff debugging.

The report is currently showing the "No pixels have changed, but the byte size is different." message in the scenario where the screenshots are different sizes, but once you resize them no pixels have changed . We don't want to do that, so adding a check if a `diff` value was set (which we don't do in the byte change case).