### PR TITLE
feat: Default the timeout for vdiff if not set to 5000, rather than 2000

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -157,7 +157,11 @@ export class WTRConfig {
 
 		const config = {};
 
-		if (timeout) config.timeout = String(timeout);
+		if (timeout) {
+			config.timeout = String(timeout);
+		} else if (group === 'vdiff') {
+			config.timeout = '5000';
+		}
 		if (open || watch) config.timeout = '0';
 		if (grep) config.grep = grep;
 		if (slow) {


### PR DESCRIPTION
As discussed, 2000 is pretty small since the Playwright `screenshot` command itself can be very slow.