### PR TITLE
fix: abort waiting for elements that are disconnected

### DIFF
--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -55,10 +55,11 @@ const nestedElem = defineCE(
 const removedElem = defineCE(
 	class extends LitElement {
 		render() {
-			setTimeout(() => {
-				this.shadowRoot.querySelector(asyncElem).remove();
-			}, 100);
-			return unsafeHTML(`<${asyncElem} id="slow"></${asyncElem}>`);
+			return html`<p>Still here</p>`;
+		}
+		async getLoadingComplete() {
+			setTimeout(() => this.remove());
+			return new Promise(() => {});
 		}
 	}
 );
@@ -292,8 +293,8 @@ describe('fixture', () => {
 		});
 
 		it('should abort waiting if elements are removed before getLoadingComplete', async() => {
-			const elem = await fixture(`<${removedElem}></${removedElem}>`);
-			expect(elem.shadowRoot.querySelector(asyncElem)).to.be.null;
+			const elem = await fixture(`<div><${removedElem}></${removedElem}></div>`);
+			expect(elem.querySelector(removedElem)).to.be.null;
 		});
 
 	});

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -52,6 +52,17 @@ const nestedElem = defineCE(
 	}
 );
 
+const removedElem = defineCE(
+	class extends LitElement {
+		render() {
+			setTimeout(() => {
+				this.shadowRoot.querySelector(asyncElem).remove();
+			}, 100);
+			return unsafeHTML(`<${asyncElem} id="slow"></${asyncElem}>`);
+		}
+	}
+);
+
 describe('fixture', () => {
 
 	afterEach(() => restore());
@@ -278,6 +289,11 @@ describe('fixture', () => {
 			timeouts.push(setTimeout(() => resolves.get('slow')(), 40));
 			const finished = await finishedPromise;
 			expect(finished.length).to.equal(2);
+		});
+
+		it('should abort waiting if elements are removed before getLoadingComplete', async() => {
+			const elem = await fixture(`<${removedElem}></${removedElem}>`);
+			expect(elem.shadowRoot.querySelector(asyncElem)).to.be.null;
 		});
 
 	});


### PR DESCRIPTION
We noticed an issue in the users repo when components load really quickly and elements they may have rendered initially are rapidly replaced with others. In this scenario, the testing framework may be `await`-ing those initial components' `getLoadingComplete()` which will now never resolve since they're no longer in the DOM.

This change uses a `MutationObserver` to short-circuit and resolve its `Promise` if an element is removed.