### PR TITLE
fix: allow empty fixture

### DIFF
--- a/src/browser/fixture.js
+++ b/src/browser/fixture.js
@@ -31,15 +31,17 @@ function getComposedChildren(node) {
 
 async function waitForElem(elem, awaitLoadingComplete = true) {
 
+	if (!elem) return;
+
 	const doWait = async() => {
 
-		const update = elem?.updateComplete;
+		const update = elem.updateComplete;
 		if (typeof update === 'object' && Promise.resolve(update) === update) {
 			await update;
 			await nextFrame();
 		}
 
-		if (awaitLoadingComplete && typeof elem?.getLoadingComplete === 'function') {
+		if (awaitLoadingComplete && typeof elem.getLoadingComplete === 'function') {
 			await elem.getLoadingComplete();
 			await nextFrame();
 		}

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -193,6 +193,10 @@ describe('fixture', () => {
 			}
 		});
 
+		it('should handle an empty fixture', async() => {
+			await fixture(html``);
+		});
+
 		it('should wait for slow element at fixture root', async() => {
 			const finishedPromise = fixture(`<${slowElem} id="slow"></${slowElem}>`)
 				.then((elem) => elem.finished);


### PR DESCRIPTION
The change in #261 attached a `MutationObserver` to `elem.parentNode` and it's possible that `elem` could be `null`.