### PR TITLE
feat: add setViewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ it('should work on small viewports', async() => {
 });
 ```
 
+To change the viewport size outside of `fixture`, use the `setViewport` command:
+
+```javascript
+import { fixture, setViewport } from '@brightspace-ui/testing';
+
+it('should adapt when viewport changes', async() => {
+  const elem = await fixture(html`<my-elem></my-elem>`);
+  await setViewport({ height: 300, width: 200 });
+  // do assertions
+});
+```
+
 #### Configuring the Language or Text Direction
 
 If the component under test has special multi-lingual or bidirectional text behavior, both `language` and `rtl` (right-to-left) options are available.

--- a/src/browser/commands.js
+++ b/src/browser/commands.js
@@ -1,5 +1,6 @@
 import { sendKeys as cmdSendKeys, sendMouse as cmdSendMouse } from '@web/test-runner-commands';
 import { requestMouseReset } from './reset.js';
+export { setViewport } from './reset.js';
 
 function getElementPosition(elem) {
 	const { x, y, width, height } = elem.getBoundingClientRect();

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,6 +1,6 @@
 import './vdiff.js';
 
 export { assert, aTimeout, defineCE, expect, html, nextFrame, oneDefaultPreventedEvent, oneEvent, waitUntil } from '@open-wc/testing';
-export { clickAt, clickElem, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem } from './commands.js';
+export { clickAt, clickElem, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem, setViewport } from './commands.js';
 export { fixture } from './fixture.js';
 export { runConstructor } from './constructor.js';

--- a/test/browser/commands.test.js
+++ b/test/browser/commands.test.js
@@ -1,4 +1,4 @@
-import { clickAt, clickElem, expect, fixture, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem } from '../../src/browser/index.js';
+import { clickAt, clickElem, expect, fixture, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem, setViewport } from '../../src/browser/index.js';
 import { html } from 'lit';
 import { spy } from 'sinon';
 
@@ -104,6 +104,45 @@ describe('commands', () => {
 				expect(mousePos.y).to.equal(0);
 			});
 		});
+	});
+
+	describe('viewport', () => {
+
+		it('should set width and height', async() => {
+			await setViewport({ height: 200, width: 300 });
+			expect(window.innerHeight).to.equal(200);
+			expect(window.innerWidth).to.equal(300);
+		});
+
+		it('should use default width and height', async() => {
+			await setViewport({ height: 200, width: 300 });
+			await setViewport();
+			expect(window.innerHeight).to.equal(800);
+			expect(window.innerWidth).to.equal(800);
+		});
+
+		it('should use default width', async() => {
+			await setViewport({ height: 200, width: 300 });
+			await setViewport({ height: 400 });
+			expect(window.innerHeight).to.equal(400);
+			expect(window.innerWidth).to.equal(800);
+		});
+
+		it('should use default height', async() => {
+			await setViewport({ height: 200, width: 300 });
+			await setViewport({ width: 400 });
+			expect(window.innerHeight).to.equal(800);
+			expect(window.innerWidth).to.equal(400);
+		});
+
+		it('should not call underlying API if values are unchanged', async() => {
+			const size = { height: 200, width: 300 };
+			const changed1 = await setViewport(size);
+			expect(changed1).to.be.true;
+			const changed2 = await setViewport(size);
+			expect(changed2).to.be.false;
+		});
+
 	});
 
 });


### PR DESCRIPTION
Exposes the underlying `setViewport` command to enable modifying its size mid-test. Adds some extra logic to avoid calling it if nothing has changed and to maintain proper resetting between `fixture` calls.