### PR TITLE
Add screenshot compression and metadata stripping

### DIFF
--- a/.github/workflows/vdiff.yml
+++ b/.github/workflows/vdiff.yml
@@ -11,7 +11,9 @@ jobs:
           node-version-file: .nvmrc
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          sudo apt-get install optipng
       - name: vdiff Tests
         uses: BrightspaceUI/actions/vdiff@main
         with:

--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -121,9 +121,15 @@ async function getTestRunnerOptions(argv = []) {
 			description: 'Run tests in Webkit',
 			order: 4
 		},
+		{
+			name: 'compression',
+			alias: 'z',
+			type: Number,
+			description: 'Compression level, 0 - 8\n[Default: 1]'
+		}
 	];
 
-	const cliArgs = commandLineArgs(optionDefinitions, { partial: true, argv });
+	const cliArgs = commandLineArgs(optionDefinitions, { partial: true, camelCase: true, argv });
 
 	if (cliArgs.help) {
 		const help = commandLineUsage([

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -139,7 +139,7 @@ function setTestInfo(session, fullTitle, testInfo) {
 	testInfoMap.set(key, testInfo);
 }
 
-export function visualDiff({ updateGoldens = false, runSubset = false, compression = 0 } = {}) {
+export function visualDiff({ updateGoldens = false, runSubset = false, compression = 1 } = {}) {
 	let currentRun = 0,
 		rootDir;
 	const clearedDirs = new Map();

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -139,7 +139,7 @@ function setTestInfo(session, fullTitle, testInfo) {
 	testInfoMap.set(key, testInfo);
 }
 
-export function visualDiff({ updateGoldens = false, runSubset = false, compression = 3 } = {}) {
+export function visualDiff({ updateGoldens = false, runSubset = false, compression = 4 } = {}) {
 	let currentRun = 0,
 		rootDir;
 	const clearedDirs = new Map();

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -1,6 +1,7 @@
 import { access, constants, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { env } from 'node:process';
+import { execSync } from 'node:child_process';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 
@@ -190,6 +191,9 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 
 				const page = session.browser.getPage(session.id);
 				await page.screenshot(screenshotOpts);
+
+				// losslessly compress and remove metadata from screenshot
+				if (isCI) execSync(`optipng -quiet -strip all ${screenshotOpts.path}`);
 
 				if (updateGoldens) {
 					return { pass: true };

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -139,7 +139,7 @@ function setTestInfo(session, fullTitle, testInfo) {
 	testInfoMap.set(key, testInfo);
 }
 
-export function visualDiff({ updateGoldens = false, runSubset = false, compression = 2 } = {}) {
+export function visualDiff({ updateGoldens = false, runSubset = false, compression = 3 } = {}) {
 	let currentRun = 0,
 		rootDir;
 	const clearedDirs = new Map();

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -139,7 +139,7 @@ function setTestInfo(session, fullTitle, testInfo) {
 	testInfoMap.set(key, testInfo);
 }
 
-export function visualDiff({ updateGoldens = false, runSubset = false, compression = 4 } = {}) {
+export function visualDiff({ updateGoldens = false, runSubset = false, compression = 0 } = {}) {
 	let currentRun = 0,
 		rootDir;
 	const clearedDirs = new Map();

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -1,7 +1,7 @@
 import { access, constants, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
-import { env, stdout } from 'node:process';
 import { unwatchFile, watchFile } from 'node:fs';
+import { env } from 'node:process';
 import { exec } from 'node:child_process';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
@@ -210,7 +210,7 @@ export function visualDiff({ updateGoldens = false, runSubset = false, compressi
 						});
 					}
 					else {
-						//stdout.write('Compression enabled, but optipng not found\n\n');
+						//console.log('Compression enabled, but optipng not found');
 					}
 				}
 				else {

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -206,7 +206,7 @@ export function visualDiff({ updateGoldens = false, runSubset = false, compressi
 									r(curr);
 								}
 							});
-							exec(`optipng -silent -strip all -o${Math.min(7, compression - 1)} '${screenshotOpts.path}'`);
+							exec(`optipng -silent -strip all -o${Math.min(7, compression - 1)} "${screenshotOpts.path}"`);
 						});
 					}
 					else {

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -139,7 +139,7 @@ function setTestInfo(session, fullTitle, testInfo) {
 	testInfoMap.set(key, testInfo);
 }
 
-export function visualDiff({ updateGoldens = false, runSubset = false, compression = 1 } = {}) {
+export function visualDiff({ updateGoldens = false, runSubset = false, compression = 2 } = {}) {
 	let currentRun = 0,
 		rootDir;
 	const clearedDirs = new Map();

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -1,7 +1,7 @@
 import { access, constants, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { env } from 'node:process';
-import { execSync } from 'node:child_process';
+import { exec } from 'node:child_process';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 
@@ -193,7 +193,7 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 				await page.screenshot(screenshotOpts);
 
 				// losslessly compress and remove metadata from screenshot
-				if (isCI) execSync(`optipng -quiet -strip all ${screenshotOpts.path}`);
+				if (isCI) exec(`optipng -strip all ${screenshotOpts.path}`);
 
 				if (updateGoldens) {
 					return { pass: true };

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -182,7 +182,7 @@ export class WTRConfig {
 		...passthroughConfig
 	} = {}) {
 
-		const { files, filter, golden, grep, group, open, watch } = this.#cliArgs;
+		const { files, filter, golden, grep, group, open, watch, compression } = this.#cliArgs;
 		const passthroughGroupNames = passthroughConfig.groups?.map(g => g.name) ?? [];
 
 		delete passthroughConfig.browsers;
@@ -223,7 +223,7 @@ export class WTRConfig {
 			config.reporters.push(visualDiffReporter({ updateGoldens: golden }));
 
 			config.plugins ??= [];
-			config.plugins.push(visualDiff({ updateGoldens: golden, runSubset: !!(filter || grep) }));
+			config.plugins.push(visualDiff({ updateGoldens: golden, runSubset: !!(filter || grep), compression }));
 
 			config.groups.push(this.visualDiffGroup);
 		}


### PR DESCRIPTION
If `optipng` is available and the `compression` level is `> 0`, we run the screenshot through compression and metaddata stripping.

- The `--compression` options is currently undocumented
- `--compression 1` will only strip metadata
- `compression` levels are equal to `optipng` "optimization levels" + 1
- We can run this on `core` and maybe another repo at different levels to decide what level we want to default to

Based on the runs I did, I think it's probably worth running at least some compression beyond the metadata stripping.