### PR TITLE
Point to latest version of font assets on CDN and preload BC Sans fonts.

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -100,42 +100,7 @@ export class WTRConfig {
 								font-weight: 700;
 								src: url(${FONT_ASSETS}Lato-700.woff2) format('woff2');
 							}
-							@font-face {
-								font-family: 'BC Sans';
-								font-style: normal;
-								font-weight: 300;
-								src: url(${FONT_ASSETS}BCSans-Light.woff2) format('woff2');
-							}
-							@font-face {
-								font-family: 'BC Sans';
-								font-style: normal;
-								font-weight: 400;
-								src: url(${FONT_ASSETS}BCSans-Regular.woff2) format('woff2');
-							}
-							@font-face {
-								font-family: 'BC Sans';
-								font-style: normal;
-								font-weight: 700;
-								src: url(${FONT_ASSETS}BCSans-Bold.woff2) format('woff2');
-							}
-							@font-face {
-								font-family: 'BC Sans';
-								font-style: italic;
-								font-weight: 300;
-								src: url(${FONT_ASSETS}BCSans-LightItalic.woff2) format('woff2');
-							}
-							@font-face {
-								font-family: 'BC Sans';
-								font-style: italic;
-								font-weight: 400;
-								src: url(${FONT_ASSETS}BCSans-Italic.woff2) format('woff2');
-							}
-							@font-face {
-								font-family: 'BC Sans';
-								font-style: italic;
-								font-weight: 700;
-								src: url(${FONT_ASSETS}BCSans-BoldItalic.woff2) format('woff2');
-							}
+
 							html {
 								font-size: 20px;
 							}

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -15,6 +15,7 @@ const BROWSER_MAP = {
 	webkit: 'webkit'
 };
 const TIMEZONE = '{&quot;name&quot;:&quot;Canada - Toronto&quot;,&quot;identifier&quot;:&quot;America/Toronto&quot;}';
+const FONT_ASSETS = 'https://s.brightspace.com/lib/fonts/0.6.0/assets/';
 const SUPPRESS_RESIZE_OBSERVER_ERRORS = `
 	<script>
 	window.addEventListener('error', (err) => {
@@ -75,8 +76,14 @@ export class WTRConfig {
 				`<!DOCTYPE html>
 				<html lang="en" data-timezone='${TIMEZONE}'>
 					<head>
-						<link rel="preload" href="https://s.brightspace.com/lib/fonts/0.5.0/assets/Lato-400.woff2" as="font" type="font/woff2" crossorigin>
-						<link rel="preload" href="https://s.brightspace.com/lib/fonts/0.5.0/assets/Lato-700.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}Lato-400.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}Lato-700.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}BCSans-Light.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}BCSans-Regular.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}BCSans-Bold.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}BCSans-LightItalic.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}BCSans-Italic.woff2" as="font" type="font/woff2" crossorigin>
+						<link rel="preload" href="${FONT_ASSETS}BCSans-BoldItalic.woff2" as="font" type="font/woff2" crossorigin>
 						<style>
 
 							* {
@@ -91,13 +98,49 @@ export class WTRConfig {
 								font-family: 'Lato';
 								font-style: normal;
 								font-weight: 400;
-								src: url(https://s.brightspace.com/lib/fonts/0.5.0/assets/Lato-400.woff2) format('woff2');
+								src: url(${FONT_ASSETS}Lato-400.woff2) format('woff2');
 							}
 							@font-face {
 								font-family: 'Lato';
 								font-style: normal;
 								font-weight: 700;
-								src: url(https://s.brightspace.com/lib/fonts/0.5.0/assets/Lato-700.woff2) format('woff2');
+								src: url(${FONT_ASSETS}Lato-700.woff2) format('woff2');
+							}
+							@font-face {
+								font-family: 'BC Sans';
+								font-style: normal;
+								font-weight: 300;
+								src: url(${FONT_ASSETS}BCSans-Light.woff2) format('woff2');
+							}
+							@font-face {
+								font-family: 'BC Sans';
+								font-style: normal;
+								font-weight: 400;
+								src: url(${FONT_ASSETS}BCSans-Regular.woff2) format('woff2');
+							}
+							@font-face {
+								font-family: 'BC Sans';
+								font-style: normal;
+								font-weight: 700;
+								src: url(${FONT_ASSETS}BCSans-Bold.woff2) format('woff2');
+							}
+							@font-face {
+								font-family: 'BC Sans';
+								font-style: italic;
+								font-weight: 300;
+								src: url(${FONT_ASSETS}BCSans-LightItalic.woff2) format('woff2');
+							}
+							@font-face {
+								font-family: 'BC Sans';
+								font-style: italic;
+								font-weight: 400;
+								src: url(${FONT_ASSETS}BCSans-Italic.woff2) format('woff2');
+							}
+							@font-face {
+								font-family: 'BC Sans';
+								font-style: italic;
+								font-weight: 700;
+								src: url(${FONT_ASSETS}BCSans-BoldItalic.woff2) format('woff2');
 							}
 							html {
 								font-size: 20px;

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -78,12 +78,6 @@ export class WTRConfig {
 					<head>
 						<link rel="preload" href="${FONT_ASSETS}Lato-400.woff2" as="font" type="font/woff2" crossorigin>
 						<link rel="preload" href="${FONT_ASSETS}Lato-700.woff2" as="font" type="font/woff2" crossorigin>
-						<link rel="preload" href="${FONT_ASSETS}BCSans-Light.woff2" as="font" type="font/woff2" crossorigin>
-						<link rel="preload" href="${FONT_ASSETS}BCSans-Regular.woff2" as="font" type="font/woff2" crossorigin>
-						<link rel="preload" href="${FONT_ASSETS}BCSans-Bold.woff2" as="font" type="font/woff2" crossorigin>
-						<link rel="preload" href="${FONT_ASSETS}BCSans-LightItalic.woff2" as="font" type="font/woff2" crossorigin>
-						<link rel="preload" href="${FONT_ASSETS}BCSans-Italic.woff2" as="font" type="font/woff2" crossorigin>
-						<link rel="preload" href="${FONT_ASSETS}BCSans-BoldItalic.woff2" as="font" type="font/woff2" crossorigin>
 						<style>
 
 							* {


### PR DESCRIPTION
This PR updates the `wtr-config.js` to point to the latest version of the CDN font assets.

It also includes the font-faces for `BC Sans` since I am planning to include this font in core's typography visual-diff test. If anyone has objection to including this, I don't mind omitting.