### PR TITLE
fix: Fix rollup.config.js for Windows

### DIFF
--- a/src/server/rollup.config.js
+++ b/src/server/rollup.config.js
@@ -3,7 +3,6 @@ import { rollupPluginHTML as html } from '@web/rollup-plugin-html';
 import { join } from 'path';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { PATHS } from './visual-diff-plugin.js';
-import { cwd } from 'node:process';
 
 export default {
 	input: join(cwd(), PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT, './temp/index.html'),

--- a/src/server/rollup.config.js
+++ b/src/server/rollup.config.js
@@ -1,10 +1,12 @@
+import { cwd } from 'node:process';
 import { rollupPluginHTML as html } from '@web/rollup-plugin-html';
 import { join } from 'path';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { PATHS } from './visual-diff-plugin.js';
+import { cwd } from 'node:process';
 
 export default {
-	input: join(process.cwd(), PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT, './temp/index.html'),
+	input: join(cwd(), PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT, './temp/index.html'),
 	output: {
 		dir: join(PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT)
 	},

--- a/src/server/rollup.config.js
+++ b/src/server/rollup.config.js
@@ -4,7 +4,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { PATHS } from './visual-diff-plugin.js';
 
 export default {
-	input: join(PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT, './temp/index.html'),
+	input: join(process.cwd(), PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT, './temp/index.html'),
 	output: {
 		dir: join(PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT)
 	},


### PR DESCRIPTION
I'm not sure exactly why this stopped working, but sometime late last year this started resulting in an error message on Windows machines:
```
.vdiff\.report\temp\index.html → .vdiff\.report...
[!] Error: Could not find any HTML files for pattern: .vdiff\.report\temp\index.html
```