### PR TITLE
Gaud-370 - Detect ALL byte changes

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -177,7 +177,7 @@ function renderResult(resultData, options) {
 			newPart = html`<div class="result-graphic padding">${ICON_TADA}<p>Hooray! No changes here.</p></div>`;
 		} else if (!resultData.info.diff && resultData.info.pixelsDiff === 0) {
 			newPart = html`<div class="result-graphic padding">${ICON_BYTES}
-				<p>No pixels have changed, but the byte size is different.</p>
+				<p>No pixels have changed, but the bytes are different.</p>
 				<p class="details">
 					Golden size: ${resultData.info.golden.byteSize} bytes<br />
 					New size: ${resultData.info.new.byteSize} bytes

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -197,7 +197,8 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 
 				const rootLength = join(rootDir, PATHS.VDIFF_ROOT).length + 1;
 
-				const screenshotImage = PNG.sync.read(await readFile(screenshotFileName));
+				const screenshotFileBuffer = await readFile(screenshotFileName);
+				const screenshotImage = PNG.sync.read(screenshotFileBuffer);
 				setTestInfo(session, payload.name, {
 					slowDuration: payload.slowDuration,
 					new: {
@@ -217,7 +218,8 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 					return { pass: false, message: 'No golden exists. Use the "--golden" CLI flag to re-run and re-generate goldens.' };
 				}
 
-				const goldenImage = PNG.sync.read(await readFile(goldenFileName));
+				const goldenFileBuffer = await readFile(goldenFileName);
+				const goldenImage = PNG.sync.read(goldenFileBuffer);
 				setTestInfo(session, payload.name, {
 					golden: {
 						height: goldenImage.height,
@@ -245,7 +247,7 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 					} else {
 						const goldenSize = (await stat(goldenFileName)).size;
 						const screenshotSize = (await stat(screenshotFileName)).size;
-						if (goldenSize !== screenshotSize) {
+						if (goldenSize !== screenshotSize || !screenshotFileBuffer.equals(goldenFileBuffer)) {
 							setTestInfo(session, payload.name, {
 								golden: {
 									byteSize: goldenSize

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -258,7 +258,7 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 								},
 								pixelsDiff
 							});
-							return { pass: false, message: 'Image diff is clean but the images do not have the same byte size.' };
+							return { pass: false, message: 'Image diff is clean but the images do not have the same bytes.' };
 						} else {
 							const success = await tryMoveFile(screenshotFileName, passFileName);
 							if (!success) return { pass: false, message: 'Problem moving file to "pass" directory.' };


### PR DESCRIPTION
To detect if a golden has the same pixels but metadata changes has caused the bytes to change, we currently try comparing the byte size between the golden and the new screenshot. I figured this was "good enough", because the chances the byte size would be identical but the bytes would be different would be very low. But turns out this is not that rare - the latest Chrome 120 changes caused 133 files to be in this situation (byte change with no byte size change).

So now, we actually do a buffer compare of the bytes to detect if something changed. I've found the perf on this to be not nearly as bad as I would expect - in `core`, it seems to add around 0ms to 100ms to each test, usually around 20ms to 40ms. And to help with this, I've moved the buffer compare up to earlier in the workflow so we can skip `pixelmatch` altogether if the two PNGs are an exact buffer match.

The workflow looks like this:
```mermaid
flowchart
    A[Do the screenshot and the golden have the same width and height?] -->|Yes| B[Do they have the same byte size?];
    A -->|No| C{Tests Fail:\nRun the existing resize logic.};
    B -->|Yes| D[Do they have the exact same buffers?];
    B -->|No| E[Run pixelmatch];
    D -->|Yes| F{Tests pass!}
    D -->|No| E
    E --> |pixelDiff == 0| G{Tests Fail:\nImage diff is clean but the images\ndo not have the same bytes.}
    E --> |pixelDiff != 0| H{Tests Fail:\nImage does not match golden.\n# pixels are different.}
```