### PR TITLE
More realistic sendKeysElem timing

### DIFF
--- a/src/browser/commands.js
+++ b/src/browser/commands.js
@@ -49,5 +49,6 @@ export async function sendKeysElem(elem, action, keys) {
 	if (elem) {
 		await focusElem(elem);
 	}
+	await new Promise(r => setTimeout(r));
 	return sendKeys(action, keys);
 }


### PR DESCRIPTION
Real user-browser interaction can't focus an element and type in the same task. This mimics a more realistic user experience, allowing time for delayed tasks to complete.

In particular, Safari is [flaking](https://github.com/BrightspaceUI/core/actions/runs/8210101107/job/22457315479?pr=4505#step:8:146) on a test where focus is retargeted after a timeout.