### PR TITLE
Replace unsafe characters in screenshot file names

### DIFF
--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -97,7 +97,7 @@ async function tryMoveFile(srcFileName, destFileName) {
 
 function extractTestPartsFromName(name) {
 	name = name.toLowerCase();
-	const parts = name.split(' ');
+	const parts = name.split(/[\s*"/\\<>:|?]/);
 	if (parts.length > 1) {
 		let dirName = parts.shift();
 		if (dirName.startsWith('d2l-')) {


### PR DESCRIPTION
Windows has a set a characters that are not allowed in file paths, so we should remove them before naming the screenshot files. Linux doesn't allow `/` but that's already included.

This approach replaces each character with a `-`, which leaves a small possibility of conflicts, but I think the suggestion would just be to be more specific in that case.