### PR TITLE
GAUD-6130 - Allow to override deviceScaleFactor

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -231,7 +231,7 @@ export class WTRConfig {
 		}
 
 		// convert all browsers to playwright
-		config.groups.forEach(g => g.browsers = this.getBrowsers(g.browsers));
+		config.groups.forEach(g => g.browsers = this.getBrowsers(g.browsers, config.deviceScaleFactor ?? (g.name === 'vdiff' ? 2 : 1)));
 
 		if (open || watch) {
 			config.testsFinishTimeout = 15 * 60 * 1000;
@@ -248,7 +248,7 @@ export class WTRConfig {
 		return config;
 	}
 
-	getBrowsers(browsers) {
+	getBrowsers(browsers, deviceScaleFactor) {
 		browsers = (this.#requestedBrowsers || browsers || DEFAULT_BROWSERS).map(b => BROWSER_MAP[b] || BROWSER_MAP.chrome);
 
 		if (!Array.isArray(browsers)) throw new TypeError('browsers must be an array');
@@ -256,7 +256,7 @@ export class WTRConfig {
 		return [...new Set(browsers)].map((b) => playwrightLauncher({
 			concurrency: b === BROWSER_MAP.firefox || this.#cliArgs.open ? 1 : undefined, // focus in Firefox unreliable if concurrency > 1 (https://github.com/modernweb-dev/web/issues/238)
 			product: b,
-			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor: 2, reducedMotion: 'reduce' }),
+			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor, reducedMotion: 'reduce' }),
 			launchOptions: {
 				headless: !this.#cliArgs.open,
 				devtools: false,


### PR DESCRIPTION
This is needed to make smaller vdiffs for the daylight site. You'd set the override at the top level of the config, and it's applied to all groups that config controls. I did this because I don't think we can set anything for the `test` or `vdiff` groups we've configured.

I didn't add any documentation about this because I don't think we _want_ people messing with this - thoughts?