### PR TITLE
GAUD-6130 - Don't replace set testsFinishTimeout value from config

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -219,7 +219,7 @@ export class WTRConfig {
 				files: this.#pattern
 			});
 		} else if (group === 'vdiff') {
-			config.testsFinishTimeout = 5 * 60 * 1000;
+			if (!config.testsFinishTimeout) config.testsFinishTimeout = 5 * 60 * 1000;
 
 			config.reporters ??= [ defaultReporter() ];
 			config.reporters.push(visualDiffReporter({ updateGoldens: golden }));


### PR DESCRIPTION
This will up the timeout from the default 2 to 5 minutes for visual diff if the consumer has set nothing. But if they have set a value, don't replace it.