### PR TITLE
GAUD-6130 - Remove doc site specific configs

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -231,7 +231,7 @@ export class WTRConfig {
 		}
 
 		// convert all browsers to playwright
-		config.groups.forEach(g => g.browsers = this.getBrowsers(g.browsers, config.deviceScaleFactor ?? (g.name === 'vdiff' ? 2 : 1)));
+		config.groups.forEach(g => g.browsers = this.getBrowsers(g.browsers));
 
 		if (open || watch) {
 			config.testsFinishTimeout = 15 * 60 * 1000;
@@ -248,7 +248,7 @@ export class WTRConfig {
 		return config;
 	}
 
-	getBrowsers(browsers, deviceScaleFactor) {
+	getBrowsers(browsers) {
 		browsers = (this.#requestedBrowsers || browsers || DEFAULT_BROWSERS).map(b => BROWSER_MAP[b] || BROWSER_MAP.chrome);
 
 		if (!Array.isArray(browsers)) throw new TypeError('browsers must be an array');
@@ -256,7 +256,7 @@ export class WTRConfig {
 		return [...new Set(browsers)].map((b) => playwrightLauncher({
 			concurrency: b === BROWSER_MAP.firefox || this.#cliArgs.open ? 1 : undefined, // focus in Firefox unreliable if concurrency > 1 (https://github.com/modernweb-dev/web/issues/238)
 			product: b,
-			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor, reducedMotion: 'reduce' }),
+			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor: 2, reducedMotion: 'reduce' }),
 			launchOptions: {
 				headless: !this.#cliArgs.open,
 				devtools: false,

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -231,7 +231,7 @@ export class WTRConfig {
 		}
 
 		// convert all browsers to playwright
-		config.groups.forEach(g => g.browsers = this.getBrowsers(g.browsers));
+		config.groups.forEach(g => g.browsers = this.getBrowsers(g.browsers, g.name === 'vdiff' ? 2 : 1));
 
 		if (open || watch) {
 			config.testsFinishTimeout = 15 * 60 * 1000;
@@ -248,7 +248,7 @@ export class WTRConfig {
 		return config;
 	}
 
-	getBrowsers(browsers) {
+	getBrowsers(browsers, deviceScaleFactor) {
 		browsers = (this.#requestedBrowsers || browsers || DEFAULT_BROWSERS).map(b => BROWSER_MAP[b] || BROWSER_MAP.chrome);
 
 		if (!Array.isArray(browsers)) throw new TypeError('browsers must be an array');
@@ -256,7 +256,7 @@ export class WTRConfig {
 		return [...new Set(browsers)].map((b) => playwrightLauncher({
 			concurrency: b === BROWSER_MAP.firefox || this.#cliArgs.open ? 1 : undefined, // focus in Firefox unreliable if concurrency > 1 (https://github.com/modernweb-dev/web/issues/238)
 			product: b,
-			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor: 2, reducedMotion: 'reduce' }),
+			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor, reducedMotion: 'reduce' }),
 			launchOptions: {
 				headless: !this.#cliArgs.open,
 				devtools: false,

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -219,7 +219,7 @@ export class WTRConfig {
 				files: this.#pattern
 			});
 		} else if (group === 'vdiff') {
-			if (!config.testsFinishTimeout) config.testsFinishTimeout = 5 * 60 * 1000;
+			config.testsFinishTimeout = 5 * 60 * 1000;
 
 			config.reporters ??= [ defaultReporter() ];
 			config.reporters.push(visualDiffReporter({ updateGoldens: golden }));


### PR DESCRIPTION
We're stepping back from migrating the Daylight site full page diffs to vdiff 2.0. This removes the stuff added only to accommodate that.  Specifically, the ability to override `testsFinishTimeout` and `deviceScaleFactor` defaults. This is pretty easy to add back if we need it again someday.