### PR TITLE
fix: allow Lit 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "command-line-args": "^5",
         "command-line-usage": "^7",
         "glob": "^10",
-        "lit": "^2",
+        "lit": "^2 || ^3",
         "page": "^1",
         "pixelmatch": "^5",
         "pngjs": "^7",
@@ -742,11 +742,11 @@
       "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -803,34 +803,6 @@
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.4.0",
         "lit": "^3.0.0"
-      }
-    },
-    "node_modules/@open-wc/scoped-elements/node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
-      }
-    },
-    "node_modules/@open-wc/scoped-elements/node_modules/lit": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.3.tgz",
-      "integrity": "sha512-l4slfspEsnCcHVRTvaP7YnkTZEZggNFywLEIhQaGhYDczG+tu/vlgm/KaWIEjIp+ZyV20r2JnZctMb8LeLCG7Q==",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.0.4",
-        "lit-html": "^3.1.2"
-      }
-    },
-    "node_modules/@open-wc/scoped-elements/node_modules/lit-element": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.5.tgz",
-      "integrity": "sha512-iTWskWZEtn9SyEf4aBG6rKT8GABZMrTWop1+jopsEOgEcugcXJGKuX5bEbkq9qfzY+XB4MAgCaSPwnNpdsNQ3Q==",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.1.2"
       }
     },
     "node_modules/@open-wc/semantic-dom-diff": {
@@ -3357,9 +3329,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.749",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.749.tgz",
-      "integrity": "sha512-LRMMrM9ITOvue0PoBrvNIraVmuDbJV5QC9ierz/z5VilMdPOVMjOtpICNld3PuXuTZ3CHH/UPxX9gHhAPwi+0Q==",
+      "version": "1.4.750",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.750.tgz",
+      "integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -5907,45 +5879,29 @@
       "dev": true
     },
     "node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.3.tgz",
+      "integrity": "sha512-l4slfspEsnCcHVRTvaP7YnkTZEZggNFywLEIhQaGhYDczG+tu/vlgm/KaWIEjIp+ZyV20r2JnZctMb8LeLCG7Q==",
       "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
       }
     },
     "node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.5.tgz",
+      "integrity": "sha512-iTWskWZEtn9SyEf4aBG6rKT8GABZMrTWop1+jopsEOgEcugcXJGKuX5bEbkq9qfzY+XB4MAgCaSPwnNpdsNQ3Q==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/lit-element/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.1.2"
       }
     },
     "node_modules/lit-html": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.3.tgz",
       "integrity": "sha512-FwIbqDD8O/8lM4vUZ4KvQZjPPNx7V1VhT7vmRB8RBAO0AU6wuTVdoXiu2CivVjEGdugvcbPNBLtPE1y0ifplHA==",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/lit/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "command-line-args": "^5",
     "command-line-usage": "^7",
     "glob": "^10",
-    "lit": "^2",
+    "lit": "^2 || ^3",
     "page": "^1",
     "pixelmatch": "^5",
     "pngjs": "^7",


### PR DESCRIPTION
In preparation for the Lit 3 upgrade, this change allows the library to be used with either Lit 2 or 3. Since it's not using any Lit 3 things (yet), I don't see why we wouldn't allow this as it'll make the upgrade a lot easier to not also need to major version bump the testing library. `@open-wc/testing` does it this way as well.

This change also upgrades this repo to Lit 3 itself, since `^2 || ^3` seems to cause NPM to prefer the larger version if it can.