### PR TITLE
Add EOF newline to metadata

### DIFF
--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -57,7 +57,7 @@ function createData(rootDir, updateGoldens, sessions) {
 		metadata.browsers = Array.from(browsers.values()).map(b => {
 			return { name: b.name, version: b.version };
 		});
-		writeFileSync(metadataPath, JSON.stringify(metadata, undefined, '\t'));
+		writeFileSync(metadataPath, `${JSON.stringify(metadata, undefined, '\t')}\n`);
 	}
 
 	return { browsers, files, numFailed, numTests };


### PR DESCRIPTION
This was driving me nuts while reviewing all @dlockhart's vdiff PRs. Gets rid of github warnings on the metadata files.