### PR TITLE
fix: split paths out into its own file

### DIFF
--- a/src/server/cli/vdiff/migrate.js
+++ b/src/server/cli/vdiff/migrate.js
@@ -3,7 +3,7 @@ import { appendFile, mkdir, readFile, rename, rm } from 'node:fs/promises';
 import { join, normalize, parse } from 'node:path';
 import commandLineArgs from 'command-line-args';
 import { glob } from 'glob';
-import { PATHS } from '../../visual-diff-plugin.js';
+import { PATHS } from '../../paths.js';
 import { stdout } from 'node:process';
 
 async function start(argv = [], local = false) {

--- a/src/server/cli/vdiff/report.js
+++ b/src/server/cli/vdiff/report.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { PATHS } from '../../visual-diff-plugin.js';
+import { PATHS } from '../../paths.js';
 import { startDevServer } from '@web/dev-server';
 
 export const report = {

--- a/src/server/paths.js
+++ b/src/server/paths.js
@@ -1,0 +1,15 @@
+import { env } from 'node:process';
+import { join } from 'node:path';
+
+const isCI = !!env['CI'];
+const METADATA_NAME = '.vdiff.json';
+const ROOT_NAME = '.vdiff';
+
+export const PATHS = {
+	FAIL: 'fail',
+	GOLDEN: 'golden',
+	PASS: 'pass',
+	METADATA: isCI ? METADATA_NAME : join(ROOT_NAME, METADATA_NAME),
+	REPORT_ROOT: '.report',
+	VDIFF_ROOT: ROOT_NAME
+};

--- a/src/server/rollup.config.js
+++ b/src/server/rollup.config.js
@@ -2,7 +2,7 @@ import { cwd } from 'node:process';
 import { rollupPluginHTML as html } from '@web/rollup-plugin-html';
 import { join } from 'path';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import { PATHS } from './visual-diff-plugin.js';
+import { PATHS } from './paths.js';
 
 export default {
 	input: join(cwd(), PATHS.VDIFF_ROOT, PATHS.REPORT_ROOT, './temp/index.html'),

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -1,21 +1,12 @@
 import { access, constants, mkdir, readdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { env } from 'node:process';
+import { PATHS } from './paths.js';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
 
 const isCI = !!env['CI'];
 const DEFAULT_TOLERANCE = 0; // TODO: Support tolerance override?
-const METADATA_NAME = '.vdiff.json';
-const ROOT_NAME = '.vdiff';
-export const PATHS = {
-	FAIL: 'fail',
-	GOLDEN: 'golden',
-	PASS: 'pass',
-	METADATA: isCI ? METADATA_NAME : join(ROOT_NAME, METADATA_NAME),
-	REPORT_ROOT: '.report',
-	VDIFF_ROOT: ROOT_NAME
-};
 
 async function checkFileExists(fileName) {
 	try {

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -1,9 +1,10 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { getTestInfo, PATHS } from './visual-diff-plugin.js';
 import { env } from 'node:process';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { getTestInfo } from './visual-diff-plugin.js';
+import { PATHS } from './paths.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const isCI = !!env['CI'];

--- a/test/browser/vdiff.config.js
+++ b/test/browser/vdiff.config.js
@@ -1,7 +1,7 @@
 import { argv, env } from 'node:process';
 import { dirname, join } from 'node:path';
 import { readFile, writeFile } from 'node:fs/promises';
-import { PATHS } from '../../src/server/visual-diff-plugin.js';
+import { PATHS } from '../../src/server/paths.js';
 import { PNG } from 'pngjs';
 
 const isCI = !!env['CI'];


### PR DESCRIPTION
This is kind of a strange thing to do, but it's the only way I can get `insights-in-ellucian-experience` to generate a vdiff report. That repo is in a bit of an odd mix of `.mjs` / `.js` files, which I think is causing Rollup when building the report to treat something as CommonJS when it otherwise wouldn't and blow up.

By making this change, `PATHS` can be imported into the Rollup build without including all the other vdiff things -- one of which is the culprit.