### PR TITLE
feat: separate out tests with byte differences in the report

### DIFF
--- a/src/server/report/app.js
+++ b/src/server/report/app.js
@@ -121,7 +121,7 @@ class App extends LitElement {
 	constructor() {
 		super();
 		this._filterBrowsers = data.browsers.map(b => b.name);
-		this._filterStatus = data.numFailed > 0 ? FILTER_STATUS.FAILED : FILTER_STATUS.ALL;
+		this._filterStatus = data.numFailed > 0 ? FILTER_STATUS.FAILED : (data.numByteDiff > 0 ? FILTER_STATUS.BYTEDIFF : FILTER_STATUS.ALL);
 		this._fullMode = FULL_MODE.GOLDEN.value;
 		this._layout = LAYOUTS.SPLIT.value;
 		this._overlay = true;
@@ -146,7 +146,10 @@ class App extends LitElement {
 			}
 			if (searchParams.has('status')) {
 				let filterStatus = searchParams.get('status');
-				if (filterStatus === FILTER_STATUS.FAILED && data.numFailed === 0) filterStatus = FILTER_STATUS.ALL;
+				if (filterStatus === FILTER_STATUS.FAILED && data.numFailed === 0 ||
+					filterStatus === FILTER_STATUS.BYTEDIFF && data.numByteDiff === 0) {
+					filterStatus = FILTER_STATUS.ALL;
+				}
 				this._filterStatus = filterStatus;
 			}
 			if (searchParams.has('browsers')) {
@@ -198,7 +201,8 @@ class App extends LitElement {
 
 		const statusFilters = [
 			{ name: FILTER_STATUS.FAILED, count: data.numFailed },
-			{ name: FILTER_STATUS.PASSED, count: data.numTests - data.numFailed },
+			{ name: FILTER_STATUS.BYTEDIFF, count: data.numByteDiff },
+			{ name: FILTER_STATUS.PASSED, count: data.numTests - data.numFailed - data.numByteDiff },
 			{ name: FILTER_STATUS.ALL, count: data.numTests }
 		];
 
@@ -434,7 +438,8 @@ class App extends LitElement {
 					if (this._filterBrowsers.includes(r.name) &&
 						(this._filterStatus === FILTER_STATUS.ALL ||
 						r.passed && this._filterStatus === FILTER_STATUS.PASSED ||
-						!r.passed && this._filterStatus === FILTER_STATUS.FAILED)) numStatusMatch++;
+						r.bytediff && this._filterStatus === FILTER_STATUS.BYTEDIFF ||
+						!r.bytediff && !r.passed && this._filterStatus === FILTER_STATUS.FAILED)) numStatusMatch++;
 				});
 				if (numStatusMatch > 0) {
 					if (lookingForNextTest) {

--- a/src/server/report/common.js
+++ b/src/server/report/common.js
@@ -77,7 +77,8 @@ export const COMMON_STYLE = css`
 export const FILTER_STATUS = {
 	ALL: 'All',
 	PASSED: 'Passed',
-	FAILED: 'Failed'
+	FAILED: 'Failed',
+	BYTEDIFF: 'Byte Diff'
 };
 
 export const FULL_MODE = {

--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -175,7 +175,7 @@ function renderResult(resultData, options) {
 		let newPart;
 		if (resultData.passed) {
 			newPart = html`<div class="result-graphic padding">${ICON_TADA}<p>Hooray! No changes here.</p></div>`;
-		} else if (!resultData.info.diff && resultData.info.pixelsDiff === 0) {
+		} else if (resultData.bytediff) {
 			newPart = html`<div class="result-graphic padding">${ICON_BYTES}
 				<p>No pixels have changed, but the bytes are different.</p>
 				<p class="details">


### PR DESCRIPTION
When Chrome makes a new release, it can sometimes result in a lot of failed tests due to byte differences. Since these are technically failures (that we're OK with), these get mixed in with potential real failures, which makes reviewing them tedious as you need to scroll through all the failed tests scanning for a legitimate failure.

This change breaks out the "byte diff" failures from the "real" failures in the report, so you can easily filter down to just the real failures and ignore the byte diff ones.

<img width="251" alt="Screenshot 2024-08-09 at 4 22 49 PM" src="https://github.com/user-attachments/assets/0ba10cdb-1cfa-45ba-8584-18f50529f429">
