### PR TITLE
fix: split byte diff filtering out from test status

### DIFF
--- a/src/server/report/app.js
+++ b/src/server/report/app.js
@@ -306,7 +306,7 @@ class App extends LitElement {
 			if (!this._filterBrowsers.includes(b.name)) return nothing;
 			const result = test.results.find(r => r.name === b.name);
 			const passed = (result !== undefined) ? result.passed : true;
-			const text = passed ? 'passed' : result.bytediff ? 'byte-diff' : 'failed';
+			const text = passed ? 'passed' : (result.bytediff ? 'byte-diff' : 'failed');
 			return html`<td class="${text}">${text}</td>`;
 		});
 		const searchParams = new URLSearchParams(window.location.search);

--- a/src/server/report/app.js
+++ b/src/server/report/app.js
@@ -11,6 +11,7 @@ import page from 'page';
 class App extends LitElement {
 	static properties = {
 		_files: { state: true },
+		_filterHideByteDiff: { state: true },
 		_filterFile: { state: true },
 		_filterTest: { state: true },
 		_fullMode: { state: true },
@@ -59,6 +60,9 @@ class App extends LitElement {
 			text-align: left;
 			white-space: normal;
 			width: 100%;
+		}
+		td.byte-diff {
+			background-color: #fbf9c6;
 		}
 		td.passed {
 			background-color: #efffd9;
@@ -121,7 +125,8 @@ class App extends LitElement {
 	constructor() {
 		super();
 		this._filterBrowsers = data.browsers.map(b => b.name);
-		this._filterStatus = data.numFailed > 0 ? FILTER_STATUS.FAILED : (data.numByteDiff > 0 ? FILTER_STATUS.BYTEDIFF : FILTER_STATUS.ALL);
+		this._filterHideByteDiff = false;
+		this._filterStatus = data.numFailed > 0 ? FILTER_STATUS.FAILED : FILTER_STATUS.ALL;
 		this._fullMode = FULL_MODE.GOLDEN.value;
 		this._layout = LAYOUTS.SPLIT.value;
 		this._overlay = true;
@@ -146,8 +151,7 @@ class App extends LitElement {
 			}
 			if (searchParams.has('status')) {
 				let filterStatus = searchParams.get('status');
-				if (filterStatus === FILTER_STATUS.FAILED && data.numFailed === 0 ||
-					filterStatus === FILTER_STATUS.BYTEDIFF && data.numByteDiff === 0) {
+				if (filterStatus === FILTER_STATUS.FAILED && data.numFailed === 0) {
 					filterStatus = FILTER_STATUS.ALL;
 				}
 				this._filterStatus = filterStatus;
@@ -155,6 +159,7 @@ class App extends LitElement {
 			if (searchParams.has('browsers')) {
 				this._filterBrowsers = searchParams.get('browsers').split(',');
 			}
+			this._filterHideByteDiff = searchParams.has('bytediff');
 			this._updateFiles();
 		});
 		page();
@@ -180,6 +185,9 @@ class App extends LitElement {
 		});
 		this._updateSearchParams({ browsers: browsers.join(',') });
 	}
+	_handleFilterByteDiffChange(e) {
+		this._updateSearchParams({ bytediff: !e.target.checked ? undefined : '1' });
+	}
 	_handleFilterStatusChange(e) {
 		this._updateSearchParams({ status: e.target.value });
 	}
@@ -201,8 +209,7 @@ class App extends LitElement {
 
 		const statusFilters = [
 			{ name: FILTER_STATUS.FAILED, count: data.numFailed },
-			{ name: FILTER_STATUS.BYTEDIFF, count: data.numByteDiff },
-			{ name: FILTER_STATUS.PASSED, count: data.numTests - data.numFailed - data.numByteDiff },
+			{ name: FILTER_STATUS.PASSED, count: data.numTests - data.numFailed },
 			{ name: FILTER_STATUS.ALL, count: data.numTests }
 		];
 
@@ -246,12 +253,22 @@ class App extends LitElement {
 				<ul>${browserDiffs}</ul>
 			</div>
 		` : nothing;
+		const byteDiffFilter = (data.numByteDiff > 0) ? html`
+			<fieldset>
+				<legend>Byte Diffs</legend>
+				<label>
+					<input type="checkbox" ?checked="${this._filterHideByteDiff}" @change="${this._handleFilterByteDiffChange}">
+					Hide tests with only file size differences (${data.numByteDiff})
+				</label>
+			</fieldset>
+		` : nothing;
 
 		return html`
 			<fieldset>
 				<legend>Test Status</legend>
 				${statusFilters.map(f => renderStatusFilter(f))}
 			</fieldset>
+			${byteDiffFilter}
 			${browserFilter}
 			${browserDiffInfo}
 		`;
@@ -289,7 +306,7 @@ class App extends LitElement {
 			if (!this._filterBrowsers.includes(b.name)) return nothing;
 			const result = test.results.find(r => r.name === b.name);
 			const passed = (result !== undefined) ? result.passed : true;
-			const text = passed ? 'passed' : 'failed';
+			const text = passed ? 'passed' : result.bytediff ? 'byte-diff' : 'failed';
 			return html`<td class="${text}">${text}</td>`;
 		});
 		const searchParams = new URLSearchParams(window.location.search);
@@ -381,7 +398,7 @@ class App extends LitElement {
 		const tabs = browsers.map((b) => {
 			const numPassed = browserResults.get(b.name);
 			return {
-				content: renderBrowserResults(b, tests, { filterStatus: this._filterStatus, fullMode: this._fullMode, layout: this._layout, showOverlay: this._overlay }),
+				content: renderBrowserResults(b, tests, { filterHideByteDiff: this._filterHideByteDiff, filterStatus: this._filterStatus, fullMode: this._fullMode, layout: this._layout, showOverlay: this._overlay }),
 				label: b.name,
 				id: b.name.toLowerCase(),
 				selected: b.name === selectedBrowser.name,
@@ -436,10 +453,10 @@ class App extends LitElement {
 				let numStatusMatch = 0;
 				t.results.forEach(r => {
 					if (this._filterBrowsers.includes(r.name) &&
+						((!r.bytediff || !this._filterHideByteDiff) &&
 						(this._filterStatus === FILTER_STATUS.ALL ||
 						r.passed && this._filterStatus === FILTER_STATUS.PASSED ||
-						r.bytediff && this._filterStatus === FILTER_STATUS.BYTEDIFF ||
-						!r.bytediff && !r.passed && this._filterStatus === FILTER_STATUS.FAILED)) numStatusMatch++;
+						!r.passed && this._filterStatus === FILTER_STATUS.FAILED))) numStatusMatch++;
 				});
 				if (numStatusMatch > 0) {
 					if (lookingForNextTest) {

--- a/src/server/report/common.js
+++ b/src/server/report/common.js
@@ -77,8 +77,7 @@ export const COMMON_STYLE = css`
 export const FILTER_STATUS = {
 	ALL: 'All',
 	PASSED: 'Passed',
-	FAILED: 'Failed',
-	BYTEDIFF: 'Byte Diff'
+	FAILED: 'Failed'
 };
 
 export const FULL_MODE = {

--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -207,7 +207,8 @@ export function renderBrowserResults(browser, tests, options) {
 
 		const resultData = t.results.find(r => r.name === browser.name);
 		if (resultData.passed && options.filterStatus === FILTER_STATUS.FAILED ||
-			!resultData.passed && options.filterStatus === FILTER_STATUS.PASSED) {
+			!resultData.passed && options.filterStatus === FILTER_STATUS.PASSED ||
+			resultData.bytediff && options.filterHideByteDiff) {
 			return acc;
 		}
 

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -95,10 +95,9 @@ function flattenResults(session, browserData, fileData) {
 				if (bytediff) {
 					browserData.numByteDiff++;
 					testData.numByteDiff++;
-				} else {
-					browserData.numFailed++;
-					testData.numFailed++;
 				}
+				browserData.numFailed++;
+				testData.numFailed++;
 			}
 			testData.results.push({
 				name: browserData.name,


### PR DESCRIPTION
Treating tests that have failed but only because of file size differences as a "status" ended up being problematic with multiple browsers. A test in one browser might have a byte diff failure whereas the other failed for another reason, so the counts get all messed up.

This changes things around to treat it as its own filter on top of whatever status filter is applied, which works out much nicer.

<img width="1153" alt="Screenshot 2024-08-13 at 4 07 26 PM" src="https://github.com/user-attachments/assets/ec738919-ccb6-46d0-b8d3-ac18dff26b5b">
