### PR TITLE
feat: set isD2LTestPage flag

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -19,6 +19,7 @@ const ALLOWED_BROWSERS = Object.keys(BROWSER_MAP);
 const DEFAULT_BROWSERS = [...new Set(Object.values(BROWSER_MAP))];
 const TIMEZONE = '{&quot;name&quot;:&quot;Canada - Toronto&quot;,&quot;identifier&quot;:&quot;America/Toronto&quot;}';
 const FONT_ASSETS = 'https://s.brightspace.com/lib/fonts/0.6.1/assets/';
+const TEST_PAGE = '<script>window.isD2LTestPage = true;</script>';
 const SUPPRESS_RESIZE_OBSERVER_ERRORS = `
 	<script>
 	window.addEventListener('error', (err) => {
@@ -53,6 +54,7 @@ export class WTRConfig {
 				`<!DOCTYPE html>
 				<html lang="en" data-timezone='${TIMEZONE}'>
 					<body>
+						${TEST_PAGE}
 						${SUPPRESS_RESIZE_OBSERVER_ERRORS}
 						<script type="module" src="${testFramework}"></script>
 					</body>
@@ -124,6 +126,7 @@ export class WTRConfig {
 						</style>
 					</head>
 					<body>
+						${TEST_PAGE}
 						${SUPPRESS_RESIZE_OBSERVER_ERRORS}
 						<script type="module" src="${testFramework}"></script>
 					</body>

--- a/test/browser/environment.test.js
+++ b/test/browser/environment.test.js
@@ -1,0 +1,9 @@
+import { expect } from '../../src/browser/index.js';
+
+describe('environment', () => {
+
+	it('should set isD2LTestPage', async() => {
+		expect(window.isD2LTestPage).to.be.true;
+	});
+
+});


### PR DESCRIPTION
Sets a flag to indicate that we're in a test environment. This will allow places [like feature flags](https://github.com/BrightspaceUI/lms-core/pull/160) to operate slightly differently.