### PR TITLE
feat: add dragDropElems (GAUD-6868)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,33 @@ it('should click at coordinate', async() => {
 });
 ```
 
+Elements configured using the [Drag & Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API) can be interacted with using `dragDropElems(sourceElem, destElem)`:
+
+```javascript
+import { dragDropElems } from '@brightspace-ui/testing';
+
+it('should drag & drop', async() => {
+  const rootElem = await fixture(html`
+    <div>
+      <div id="source" draggable="true"></div>
+      <div id="dest"></div>
+    </div>
+  `);
+  // NOTE: destination must have "dragover" and "drop"
+  // event listeners added for the drag & drop API to function
+  await dragDropElems(
+    rootElem.querySelector('#source'),
+    rootElem.querySelector('#target')
+  );
+  // do assertions
+});
+
+it('should click at coordinate', async() => {
+  await clickAt(100, 200);
+  // do assertions
+});
+```
+
 ### Using the Keyboard
 
 To place focus on an element using the keyboard, use `focusElem(elem)`. Doing so will trigger its `:focus-visible` CSS pseudo-class.

--- a/src/browser/commands.js
+++ b/src/browser/commands.js
@@ -24,6 +24,15 @@ export async function clickElem(elem) {
 	return clickAt(position.x, position.y);
 }
 
+export async function dragDropElems(elem, toElem) {
+	const fromPosition = getElementPosition(elem);
+	const toPosition = getElementPosition(toElem);
+	await sendMouse({ type: 'move', position: [fromPosition.x, fromPosition.y] });
+	await sendMouse({ type: 'down' });
+	await sendMouse({ type: 'move', position: [toPosition.x, toPosition.y] });
+	await sendMouse({ type: 'up' });
+}
+
 export async function focusElem(elem) {
 	await cmdSendKeys({ press: 'Shift' }); // Tab moves focus, Escape causes dismissible things to close
 	elem.focus({ focusVisible: true });

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -1,6 +1,6 @@
 import './vdiff.js';
 
 export { assert, aTimeout, defineCE, expect, html, nextFrame, oneDefaultPreventedEvent, oneEvent, waitUntil } from '@open-wc/testing';
-export { clickAt, clickElem, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem, setViewport } from './commands.js';
+export { clickAt, clickElem, dragDropElems, focusElem, hoverAt, hoverElem, sendKeys, sendKeysElem, setViewport } from './commands.js';
 export { fixture } from './fixture.js';
 export { runConstructor } from './constructor.js';


### PR DESCRIPTION
As requested, here's a new "drag & drop" test API that leverages the underlying commands. I chose not to also expose the mouse move/down/up commands for now until they're truly needed.