### PR TITLE
Report tests excluded via grep as skipped instead of failed

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -23,7 +23,7 @@ const defaultReporterGrep = () => {
 		results.suites?.forEach(suite => removeGrepFailures(suite));
 	};
 
-	return { ...dr, ...{
+	return { ...dr,
 		getTestProgress({ sessions, ...others }) {
 			sessions.forEach(session => {
 				passed = true;
@@ -34,7 +34,7 @@ const defaultReporterGrep = () => {
 			});
 			return dr.getTestProgress({ sessions, ...others });
 		}
-	} };
+	};
 };
 
 const DEFAULT_PATTERN = type => `./test/**/*.${type}.js`;

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -8,7 +8,7 @@ import { visualDiffReporter } from './visual-diff-reporter.js';
 
 const defaultReporterGrep = () => {
 	const dr = defaultReporter();
-	let passed = true;
+	let passed;
 	const removeGrepFailures = results => {
 		results.tests?.forEach(test => {
 			if (!test.passed) {
@@ -24,12 +24,15 @@ const defaultReporterGrep = () => {
 	};
 
 	return { ...dr, ...{
-		reportTestFileResults({ sessionsForTestFile, ...others }) {
-			sessionsForTestFile.forEach(session => {
-				removeGrepFailures(session.testResults);
-				session.passed = passed;
+		getTestProgress({ sessions, ...others }) {
+			sessions.forEach(session => {
+				passed = true;
+				if (session.testResults) {
+					removeGrepFailures(session.testResults);
+					session.passed = passed;
+				}
 			});
-			return dr.reportTestFileResults({ sessionsForTestFile, ...others });
+			return dr.getTestProgress({ sessions, ...others });
 		}
 	} };
 };

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -8,8 +8,8 @@ import { visualDiffReporter } from './visual-diff-reporter.js';
 
 const defaultReporterGrep = () => {
 	const dr = defaultReporter();
-	let passed;
 	const removeGrepFailures = results => {
+		let passed = true;
 		results.tests?.forEach(test => {
 			if (!test.passed) {
 				if (!test.error) {
@@ -21,15 +21,14 @@ const defaultReporterGrep = () => {
 		});
 
 		results.suites?.forEach(suite => removeGrepFailures(suite));
+		return passed;
 	};
 
 	return { ...dr,
 		getTestProgress({ sessions, ...others }) {
 			sessions.forEach(session => {
-				passed = true;
 				if (session.testResults) {
-					removeGrepFailures(session.testResults);
-					session.passed = passed;
+					session.passed = removeGrepFailures(session.testResults) && !session.errors.length;
 				}
 			});
 			return dr.getTestProgress({ sessions, ...others });

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -8,11 +8,15 @@ import { visualDiffReporter } from './visual-diff-reporter.js';
 
 const defaultReporterGrep = () => {
 	const dr = defaultReporter();
-
+	let passed = true;
 	const removeGrepFailures = results => {
 		results.tests?.forEach(test => {
-			if (!test.passed && !test.error) {
-				test.skipped = true;
+			if (!test.passed) {
+				if (!test.error) {
+					test.skipped = true;
+				} else {
+					passed = false;
+				}
 			}
 		});
 
@@ -23,7 +27,7 @@ const defaultReporterGrep = () => {
 		reportTestFileResults({ sessionsForTestFile, ...others }) {
 			sessionsForTestFile.forEach(session => {
 				removeGrepFailures(session.testResults);
-				session.passed = !session.errors.length;
+				session.passed = passed;
 			});
 			return dr.reportTestFileResults({ sessionsForTestFile, ...others });
 		}


### PR DESCRIPTION
[GAUD-6720](https://desire2learn.atlassian.net/browse/GAUD-6720): @brightspace-ui/testing: tests which are skipped report as failed

Currently tests that are excluded from a run via the `grep` option are reported as failed. This modifies test results as they come in to properly report as skipped.

[GAUD-6720]: https://desire2learn.atlassian.net/browse/GAUD-6720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ