### PR TITLE
Click and hold to exaggerate vdiff result differences

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -63,6 +63,18 @@ export const RESULT_STYLE = css`
 		position: absolute;
 		top: 0;
 	}
+	.result-overlay img:active {
+		filter:
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red)
+			drop-shadow(0 0 0.5px red);
+	}
 	.result-part-info {
 		align-items: center;
 		display: flex;


### PR DESCRIPTION
When vdiff changes are few and small (common for browser updates), it can be very difficult to spot the differences, even with the diff overlay.

This adds a "click to exaggerate" feature to blow up the differences in the overlay, making it easier to inspect changes.

![vdiff-exaggerate](https://github.com/user-attachments/assets/23c311ef-0d6f-4112-9d34-dcec379dd421)
