### PR TITLE
Fix session passed state logic

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -11,17 +11,16 @@ const defaultReporterGrep = () => {
 	const removeGrepFailures = results => {
 		let passed = true;
 		results.tests?.forEach(test => {
-			if (!test.passed) {
-				if (!test.error) {
-					test.skipped = true;
-				} else {
-					passed = false;
-				}
+			if (test.error) {
+				passed = false;
+			} else if (!test.passed) {
+				test.skipped = true;
 			}
 		});
 
-		results.suites?.forEach(suite => removeGrepFailures(suite));
-		return passed;
+		const passedStates = results.suites?.map(suite => removeGrepFailures(suite));
+		const nestedPassed = !passedStates?.includes(false) ?? true;
+		return passed && nestedPassed;
 	};
 
 	return { ...dr,

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -19,7 +19,7 @@ const defaultReporterGrep = () => {
 		});
 
 		const passedStates = results.suites?.map(suite => removeGrepFailures(suite));
-		const nestedPassed = !passedStates?.includes(false) ?? true;
+		const nestedPassed = !passedStates?.includes(false);
 		return passed && nestedPassed;
 	};
 


### PR DESCRIPTION
Nested tests were not being included in the overall `passed` state of a session, causing failed tests to (almost always) _not_ exit with an error code.

More details in [this thread](https://d2l.slack.com/archives/C04BR06RN22/p1726065614383249)