### PR TITLE
fix reporter

### DIFF
--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -90,7 +90,7 @@ function flattenResults(session, browserData, fileData) {
 				});
 			}
 			const testData = fileData.tests.get(testName);
-			const bytediff = !t.passed && !info.diff && info.pixelsDiff === 0;
+			const bytediff = !t.passed && !!info?.diff && info?.pixelsDiff === 0;
 			if (!t.passed) {
 				if (bytediff) {
 					browserData.numByteDiff++;

--- a/test/browser/media.vdiff.js
+++ b/test/browser/media.vdiff.js
@@ -25,7 +25,7 @@ describe('media', () => {
 
 	it('default', async() => {
 		const elem = await fixture(`<${mediaTag}></${mediaTag}>`);
-		await new Promise(resolve => setTimeout(resolve, 20000));
+		elem.shadowRoot.querySelector('thing').throwAnError();
 		await expect(elem).to.be.golden();
 	});
 

--- a/test/browser/media.vdiff.js
+++ b/test/browser/media.vdiff.js
@@ -25,7 +25,6 @@ describe('media', () => {
 
 	it('default', async() => {
 		const elem = await fixture(`<${mediaTag}></${mediaTag}>`);
-		elem.shadowRoot.querySelector('thing').throwAnError();
 		await expect(elem).to.be.golden();
 	});
 

--- a/test/browser/media.vdiff.js
+++ b/test/browser/media.vdiff.js
@@ -23,11 +23,6 @@ const mediaTag = defineCE(
 
 describe('media', () => {
 
-	it('default', async() => {
-		const elem = await fixture(`<${mediaTag}></${mediaTag}>`);
-		await expect(elem).to.be.golden();
-	});
-
 	['screen', 'print'].forEach(media => {
 		it(media, async() => {
 			const elem = await fixture(`<${mediaTag}></${mediaTag}>`, { media });

--- a/test/browser/media.vdiff.js
+++ b/test/browser/media.vdiff.js
@@ -23,6 +23,12 @@ const mediaTag = defineCE(
 
 describe('media', () => {
 
+	it('default', async() => {
+		const elem = await fixture(`<${mediaTag}></${mediaTag}>`);
+		await new Promise(resolve => setTimeout(resolve, 20000));
+		await expect(elem).to.be.golden();
+	});
+
 	['screen', 'print'].forEach(media => {
 		it(media, async() => {
 			const elem = await fixture(`<${mediaTag}></${mediaTag}>`, { media });


### PR DESCRIPTION
A regression was introduced with [the new byte-diff stuff](https://github.com/BrightspaceUI/testing/pull/459) where it's assuming that if a test fails that `info` will always get set. That's not true if the test fails because it threw an exception, so this code needs to be more resilient.