### PR TITLE
Add system/os data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4090,11 +4090,10 @@
       }
     },
     "node_modules/eslint-config-brightspace": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-brightspace/-/eslint-config-brightspace-1.2.1.tgz",
-      "integrity": "sha512-48P/5ZIfVEixNpOm9ZOKu4/X3a2JHou3Am7GQL7DLdcG2Kxn467KclvZrUqUcH2LMIxnMc8MCr71s6yoez/0fw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-brightspace/-/eslint-config-brightspace-1.2.2.tgz",
+      "integrity": "sha512-xQhWXutfJ1SY9jzO/6fIanzU9gevZSsJpILkB8GDNJzj0/doOr2U0wXJIvfgGRQfioAudMdiFyU2f8BIyyA6wg==",
       "dev": true,
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@babel/eslint-parser": ">= 7",
         "eslint": ">= 7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:browser:other": "npx d2l-test-runner --files \"./test/browser/**/*.test.js\"",
     "test:browser:ctor": "npx d2l-test-runner --config ./test/browser/ctor.config.js",
     "test:server": "mocha './test/server/**/*.test.js'",
-    "test:vdiff": "npx d2l-test-runner vdiff --config ./test/browser/vdiff.config.js"
+    "test:vdiff": "npx d2l-test-runner vdiff $npm_config_sub --config ./test/browser/vdiff.config.js"
   },
   "bin": {
     "d2l-test-runner": "./bin/d2l-test-runner.js",

--- a/src/server/report/app.js
+++ b/src/server/report/app.js
@@ -253,6 +253,23 @@ class App extends LitElement {
 				<ul>${browserDiffs}</ul>
 			</div>
 		` : nothing;
+
+		const systemDiffs = Object.entries(data.system).reduce((acc, [k, v]) => {
+			const previous = data.system.previous[k] || 'unknown';
+			if (k === 'previous' || previous === v) {
+				return acc;
+			}
+			return acc.push(html`
+				<li>${k}: <strong>${data.system.previous[k]}</strong> to <strong>${v}</strong></li>
+			`) && acc;
+		}, []);
+		const systemDiffInfo = systemDiffs.length ? html`
+			<div class="browser-diff">
+				<div class="browser-diff-title">System Changes</div>
+				<ul>${systemDiffs}</ul>
+			</div>
+		` : nothing;
+
 		const byteDiffFilter = (data.numByteDiff > 0) ? html`
 			<fieldset>
 				<legend>Byte Diffs</legend>
@@ -271,6 +288,7 @@ class App extends LitElement {
 			${byteDiffFilter}
 			${browserFilter}
 			${browserDiffInfo}
+			${systemDiffInfo}
 		`;
 
 	}

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -1,6 +1,6 @@
+import * as os from 'node:os';
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import * as os from 'node:os';
 import { env } from 'node:process';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -63,25 +63,19 @@ function createData(rootDir, updateGoldens, sessions) {
 	const system = {
 		platform: os.platform(),
 		release: os.release(),
-		arch: os.arch(),
-		previous: metadata.system && {
-			platform: metadata.system.platform,
-			release: metadata.system.release,
-			arch: metadata.system.arch
-		}
+		arch: os.arch()
 	};
 
 	if (isCI || updateGoldens) {
 		metadata.browsers = Array.from(browsers.values()).map(b => {
 			return { name: b.name, version: b.version };
 		});
-		metadata.system = {
-			platform: system.platform,
-			release: system.release,
-			arch: system.arch
-		};
+		metadata.system = system;
 		writeFileSync(metadataPath, `${JSON.stringify(metadata, undefined, '\t')}\n`);
 	}
+
+	const { previous: gc, ...previous } = metadata.system;
+	system.previous = previous;
 
 	return { browsers, files, numByteDiff, numFailed, numTests, system };
 

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -1,5 +1,6 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import * as os from 'node:os';
 import { env } from 'node:process';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -59,14 +60,30 @@ function createData(rootDir, updateGoldens, sessions) {
 		});
 	});
 
+	const system = {
+		platform: os.platform(),
+		release: os.release(),
+		arch: os.arch(),
+		previous: metadata.system && {
+			platform: metadata.system.platform,
+			release: metadata.system.release,
+			arch: metadata.system.arch
+		}
+	};
+
 	if (isCI || updateGoldens) {
 		metadata.browsers = Array.from(browsers.values()).map(b => {
 			return { name: b.name, version: b.version };
 		});
+		metadata.system = {
+			platform: system.platform,
+			release: system.release,
+			arch: system.arch
+		};
 		writeFileSync(metadataPath, `${JSON.stringify(metadata, undefined, '\t')}\n`);
 	}
 
-	return { browsers, files, numByteDiff, numFailed, numTests };
+	return { browsers, files, numByteDiff, numFailed, numTests, system };
 
 }
 


### PR DESCRIPTION
Adds system data to track changes between runs. This should solve confusion around diffs where there were no code changes but any of the OS platform, OS release, or system architecture changes between runs, such as when our CI runners are updated, or a local repo is copied to a new machine.

Example:
![Screenshot 2024-10-25 at 5 30 11 PM](https://github.com/user-attachments/assets/9367257b-3fd2-41e0-8f1b-83a25b448bf5)
