### PR TITLE
GAUD-7681: treat byte diffs properly

### DIFF
--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -101,7 +101,7 @@ function flattenResults(session, browserData, fileData) {
 				});
 			}
 			const testData = fileData.tests.get(testName);
-			const bytediff = !t.passed && !!info?.diff && info?.pixelsDiff === 0;
+			const bytediff = !t.passed && info?.diff === undefined && info?.pixelsDiff === 0;
 			if (!t.passed) {
 				if (bytediff) {
 					browserData.numByteDiff++;


### PR DESCRIPTION
When working in core on a change that caused a large number of zero pixel but many byte diffs, I realized that the vdiff report was misidentifying them.