### PR TITLE
Add a cursor to indicate available exaggeration

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -62,8 +62,12 @@ export const RESULT_STYLE = css`
 		left: 0;
 		position: absolute;
 		top: 0;
+		cursor: zoom-in;
 	}
-	.result-overlay img:active {
+	.result-overlay img + img {
+		position: absolute;
+		inset: 0;
+		opacity: 0.003;
 		filter:
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
@@ -74,6 +78,9 @@ export const RESULT_STYLE = css`
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red);
+	}
+	.result-overlay img + img:active {
+		opacity: 1;
 	}
 	.result-part-info {
 		align-items: center;
@@ -180,7 +187,11 @@ function renderResult(resultData, options) {
 	const goldenExists = (resultData.info.golden !== undefined);
 
 	const overlay = (goldenExists && options.showOverlay && !resultData.passed && resultData.info.diff) ?
-		html`<div class="result-overlay"><img src="../${resultData.info.diff}" loading="lazy" alt=""></div>` : nothing;
+		html`
+		<div class="result-overlay">
+			<img src="../${resultData.info.diff}" loading="lazy" alt="">
+			<img src="../${resultData.info.diff}" loading="lazy" alt="">
+		</div>` : nothing;
 
 	const goldenPart = !goldenExists ?
 		html`<div class="result-graphic padding">${ICON_NO_GOLDEN}<p>No golden exists for this test... yet.</p></div>` :

--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -59,15 +59,13 @@ export const RESULT_STYLE = css`
 	}
 	.result-overlay {
 		background: hsla(0, 0%, 100%, 0.8);
+		cursor: zoom-in;
 		left: 0;
 		position: absolute;
 		top: 0;
-		cursor: zoom-in;
 	}
 	.result-overlay img + img {
-		position: absolute;
 		inset: 0;
-		opacity: 0.003;
 		filter:
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
@@ -78,6 +76,8 @@ export const RESULT_STYLE = css`
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red);
+		opacity: 0.003;
+		position: absolute;
 	}
 	.result-overlay img + img:active {
 		opacity: 1;

--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -65,7 +65,6 @@ export const RESULT_STYLE = css`
 		top: 0;
 	}
 	.result-overlay img + img {
-		inset: 0;
 		filter:
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
@@ -76,6 +75,7 @@ export const RESULT_STYLE = css`
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red);
+		inset: 0;
 		opacity: 0.003;
 		position: absolute;
 	}


### PR DESCRIPTION
[GAUD-7735](https://desire2learn.atlassian.net/browse/GAUD-7735): Add vdiff new golden exaggeration cursor

The "exaggerate" feature has never made itself obvious to users, but a constant title/tooltip always seemed more intrusive than helpful. @dlockhart suggested a zoom cursor, which is an excellent idea, so here it is.

The filter was also always slow to render, so there was a significant delay before exaggeration would show. A second exaggerated copy of the image now always renders (hidden until activated) to make showing it much faster.

[GAUD-7735]: https://desire2learn.atlassian.net/browse/GAUD-7735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ