### PR TITLE
feat: add inline-end variable

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -81,14 +81,16 @@ export class WTRConfig {
 						<link rel="preload" href="${FONT_ASSETS}Lato-700.woff2" as="font" type="font/woff2" crossorigin>
 						<style>
 
-							* {
+							html {
 								--d2l-document-direction: ltr;
 								--d2l-mirror-transform: none;
+								--d2l-inline-end: right;
 							}
 
 							html[dir="rtl"] * {
 								--d2l-document-direction: rtl;
 								--d2l-mirror-transform: scale(-1, 1);
+								--d2l-inline-end: left;
 							}
 
 							@font-face {


### PR DESCRIPTION
GAUD-8056

As [discussed here](https://github.com/BrightspaceUI/core/pull/5780), this allows for background images to be positioned without needing the `RtlMixin`. This needs to be duplicated for tests since this can't rely on core.