### PR TITLE
LURV-6113 Use Playwright locale setting instead of env.LANG

### DIFF
--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -225,9 +225,8 @@ export class WTRConfig {
 		return [...new Set(browsers)].map((b) => playwrightLauncher({
 			concurrency: b === BROWSER_MAP.firefox || this.#cliArgs.open ? 1 : undefined, // focus in Firefox unreliable if concurrency > 1 (https://github.com/modernweb-dev/web/issues/238)
 			product: b,
-			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor, reducedMotion: 'reduce' }),
+			createBrowserContext: ({ browser }) => browser.newContext({ deviceScaleFactor, reducedMotion: 'reduce', locale: 'en-us' }),
 			launchOptions: {
-				env: { ...env, LANG: 'en_US.UTF-8' },
 				headless: !this.#cliArgs.open,
 				devtools: false,
 				slowMo: this.#cliArgs.slowmo || 0,

--- a/test/browser/environment.test.js
+++ b/test/browser/environment.test.js
@@ -6,4 +6,10 @@ describe('environment', () => {
 		expect(window.isD2LTestPage).to.be.true;
 	});
 
+	it('should default to "en-us" locale', async() => {
+		// Firefox always returns the region portion in uppercase
+		// https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/language
+		expect(navigator.language.toLowerCase()).to.equal('en-us');
+	});
+
 });


### PR DESCRIPTION
Probably a very uncommon issue but it causes issues when running tests on the public awards ui due to how it handles languages.

On windows, tests run in chromium are using the system region settings for the browser's language.  Firefox and webkit are always using "en-us" even without the LANG env var set.

The LANG env variable doesn't affect chromium on windows systems (https://peter.sh/experiments/chromium-command-line-switches/#lang) so this switches to using playwright's `locale` setting (https://playwright.dev/docs/api/class-browsertype#browser-type-launch-persistent-context-option-locale) which does correctly set chromium's language on windows.