### PR TITLE
GAUD-8728 - Undo the changes to add a second overlay for faster pixel exaggeration

### DIFF
--- a/src/server/report/result.js
+++ b/src/server/report/result.js
@@ -64,7 +64,7 @@ export const RESULT_STYLE = css`
 		position: absolute;
 		top: 0;
 	}
-	.result-overlay img + img {
+	.result-overlay img:active {
 		filter:
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
@@ -75,12 +75,6 @@ export const RESULT_STYLE = css`
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red)
 			drop-shadow(0 0 0.5px red);
-		inset: 0;
-		opacity: 0.003;
-		position: absolute;
-	}
-	.result-overlay img + img:active {
-		opacity: 1;
 	}
 	.result-part-info {
 		align-items: center;
@@ -189,7 +183,6 @@ function renderResult(resultData, options) {
 	const overlay = (goldenExists && options.showOverlay && !resultData.passed && resultData.info.diff) ?
 		html`
 		<div class="result-overlay">
-			<img src="../${resultData.info.diff}" loading="lazy" alt="">
 			<img src="../${resultData.info.diff}" loading="lazy" alt="">
 		</div>` : nothing;
 


### PR DESCRIPTION
Undoing the part of https://github.com/BrightspaceUI/testing/pull/652 that added a second overlay with the filter always applied to speed up the "pixel exaggeration" feature.

This second copy with `filter` applied can make scrolling really laggy, but this is all display dependent. Undoing this means the "pixel exaggeration" click may be laggy again (also depending on the screen/display). Not sure if there's a "best of both worlds" solution, but I will add a story to investigate more. In the meantime, I think it makes sense to prioritize scrolling smoothness.

This may also be affected by all the changes from https://github.com/BrightspaceUI/testing/pull/720 that will be applied eventually.