### PR TITLE
fix: mark just failed alt-tests as failed

### DIFF
--- a/src/server/visual-diff-info.js
+++ b/src/server/visual-diff-info.js
@@ -20,6 +20,7 @@ export class TestInfoManager {
 				testInfo.new = { ...info.new, ...testInfo.new };
 			}
 			testInfo.diff = testInfo.diff || info.diff;
+			testInfo.byteSizeDiff = testInfo.byteSizeDiff || info.byteSizeDiff;
 		}
 		const tests = testInfoMap.get(this.key) || {};
 		testInfoMap.set(this.key, { ...tests, [alt]: testInfo });

--- a/src/server/visual-diff-plugin.js
+++ b/src/server/visual-diff-plugin.js
@@ -303,7 +303,8 @@ export function visualDiff({ updateGoldens = false, runSubset = false } = {}) {
 							new: {
 								byteSize: screenshotSize
 							},
-							pixelsDiff
+							pixelsDiff,
+							byteSizeDiff: true
 						}, alt);
 						return { pass: false, message: 'Image diff is clean but the images do not have the same bytes.' };
 					}

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -106,7 +106,7 @@ function flattenResults(session, browserData, fileData) {
 				const testData = fileData.tests.get(testName);
 				const passed = !!(info?.golden) && !(info?.diff) && !(info?.pixelsDiff);
 				const bytediff = info?.diff === undefined && info?.pixelsDiff === 0;
-				if (passed) {
+				if (!passed) {
 					if (bytediff) {
 						browserData.numByteDiff++;
 						testData.numByteDiff++;

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -104,10 +104,9 @@ function flattenResults(session, browserData, fileData) {
 					});
 				}
 				const testData = fileData.tests.get(testName);
-				const passed = !!(info?.golden) && !(info?.diff) && !(info?.pixelsDiff);
-				const bytediff = info?.diff === undefined && info?.pixelsDiff === 0;
+				const passed = !!(info.golden) && !(info.pixelsDiff) && !(info.byteSizeDiff);
 				if (!passed) {
-					if (bytediff) {
+					if (info.byteSizeDiff) {
 						browserData.numByteDiff++;
 						testData.numByteDiff++;
 					}
@@ -119,7 +118,7 @@ function flattenResults(session, browserData, fileData) {
 					duration: t.duration,
 					error: t.error?.message,
 					passed,
-					bytediff,
+					bytediff: info.byteSizeDiff,
 					info: info
 				});
 			}

--- a/src/server/visual-diff-reporter.js
+++ b/src/server/visual-diff-reporter.js
@@ -104,8 +104,9 @@ function flattenResults(session, browserData, fileData) {
 					});
 				}
 				const testData = fileData.tests.get(testName);
-				const bytediff = !t.passed && info?.diff === undefined && info?.pixelsDiff === 0;
-				if (!t.passed) {
+				const passed = !!(info?.golden) && !(info?.diff) && !(info?.pixelsDiff);
+				const bytediff = info?.diff === undefined && info?.pixelsDiff === 0;
+				if (passed) {
 					if (bytediff) {
 						browserData.numByteDiff++;
 						testData.numByteDiff++;
@@ -117,7 +118,7 @@ function flattenResults(session, browserData, fileData) {
 					name: browserData.name,
 					duration: t.duration,
 					error: t.error?.message,
-					passed: t.passed,
+					passed,
 					bytediff,
 					info: info
 				});


### PR DESCRIPTION
[GAUD-9495](https://desire2learn.atlassian.net/browse/GAUD-9495)

If alt tests are defined and any of them fail, the reporter would mark(and count) ALL the alt tests as failed, even if they passed

[GAUD-9495]: https://desire2learn.atlassian.net/browse/GAUD-9495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ