### PR TITLE
Generalize default glob pattern for test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Use the `d2l-test-runner` binary to execute a set of tests and report their resu
 | timeout | `Number` | `2000` | Test timeout threshold in ms |
 | filter | `String` | | Filter test files by replacing wildcards with this glob |
 | grep | `String` | | Only run tests matching this string or regexp |
-| files | `String` | `'./test/**/*.<group>.js'` | Test files to run. Path or glob. |
+| files | `String` | `'./**/test/**/*.<group>.js'` | Test files to run. Path or glob. |
 | config | `String` | `'./d2l-test-runner.config.js'` | Location of config file |
 | watch | `Boolean` | `false` | Reload tests on file changes. Allows debugging in all browsers. |
 | open | `Boolean` | `false` | Open the browser in headed mode |
@@ -461,9 +461,9 @@ export default {
 
 Tests are organized into groups, which can be configured and run together.
 
-The group name appears in the default `files` pattern (`'./test/**/*.<group>.js'`), making it typical for test files to have the group name as part of their extension. For example, the default group is `'test'` so all test files named `*.test.js` will belong to it by default. Similarly, the `vdiff` group contains files named `*.vdiff.js`.
+The group name appears in the default `files` pattern (`'./**/test/**/*.<group>.js'`), making it typical for test files to have the group name as part of their extension. For example, the default group is `'test'` so all test files named `*.test.js` will belong to it by default. Similarly, the `vdiff` group contains files named `*.vdiff.js`.
 
-To run tests which match the pattern `'./test/**/*.mygroup.js'`:
+To run tests which match the pattern `'./**/test/**/*.mygroup.js'`:
 ```bash
 d2l-test-runner --group mygroup
 ```
@@ -488,9 +488,9 @@ While writing or debugging tests, it can be desirable to focus the runner on a s
 
 Use the `filter` option to filter by file name. It replaces any wildcards in the file name portion of the `files` pattern with the provided [glob](https://en.wikipedia.org/wiki/Glob_(programming)).
 
-For example, with the `'test'` group and default pattern `'./test/**/*.<group>.js'`, passing `d2l-test-runner --filter foo` will run tests which match `'./test/**/foo.test.js'`.
+For example, with the `'test'` group and default pattern `'./**/test/**/*.<group>.js'`, passing `d2l-test-runner --filter foo` will run tests which match `'./**/test/**/foo.test.js'`.
 
-Wildcards can still be used but need to be escaped. So `d2l-test-runner --filter foo\*` will run tests which match `'./test/**/foo*.test.js'`.
+Wildcards can still be used but need to be escaped. So `d2l-test-runner --filter foo\*` will run tests which match `'./**/test/**/foo*.test.js'`.
 
 ### By Test Name
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -156,7 +156,7 @@ By default, `d2l-test-runner` will:
 
 * Run in Chrome, Firefox and Safari (except `vdiff` just runs in Chrome)
 * Enable the `--node-resolve` flag
-* Look for tests in `./test/**/*.test.js` (using the `test` group)
+* Look for tests in `./**/test/**/*.test.js` (using the `test` group)
 * Suppress `ResizeObserver` errors (a common reason repos use a config file)
 
 Due to these new defaults, if the repo is using a `web-test-runner.config.js`, it may no longer be necessary and could be removed. If the config file is necessary, rename it to `d2l-test-runner.config.js`.
@@ -165,7 +165,7 @@ Before
 
 ```yml
   "scripts": {
-    "test:unit": "web-test-runner --files \"./test/**/*.test.js\" --node-resolve"
+    "test:unit": "web-test-runner --files \"./**/test/**/*.test.js\" --node-resolve"
   }
 ```
 

--- a/src/server/cli/test-runner.js
+++ b/src/server/cli/test-runner.js
@@ -16,7 +16,7 @@ async function getTestRunnerOptions(argv = []) {
 			name: 'files',
 			type: String,
 			multiple: true,
-			description: 'Test files to run. Path or glob.\n[Default: ./test/**/*.<group>.js]',
+			description: 'Test files to run. Path or glob.\n[Default: ./**/test/**/*.<group>.js]',
 			order: 8
 		},
 		{

--- a/src/server/wtr-config.js
+++ b/src/server/wtr-config.js
@@ -35,7 +35,7 @@ const defaultReporterGrep = () => {
 	};
 };
 
-const DEFAULT_PATTERN = type => `./test/**/*.${type}.js`;
+const DEFAULT_PATTERN = type => `./**/test/**/*.${type}.js`;
 const DEFAULT_TEST_REPORTING = !!env['CI'];
 const BROWSER_MAP = {
 	chrome: 'chromium',

--- a/test/server/cli/test-runner.test.js
+++ b/test/server/cli/test-runner.test.js
@@ -14,7 +14,7 @@ describe('runner.getOptions()', () => {
 		expect(opts.config.groups).to.be.an('array').with.length(1);
 		expect(opts.config.groups[0]).to.deep.include({
 			name: 'test',
-			files: [ './test/**/*.test.js', '!**/node_modules/**/*' ]
+			files: [ './**/test/**/*.test.js', '!**/node_modules/**/*' ]
 		});
 	});
 

--- a/test/server/wtr-config.test.js
+++ b/test/server/wtr-config.test.js
@@ -34,7 +34,7 @@ describe('WTRConfig', () => {
 			const group = config.groups[0];
 			expect(config.groups).to.be.an('array').that.has.length(1);
 			expect(group.name).to.equal('implicit-group');
-			expect(group.files).to.include.members(['./test/**/*.implicit-group.js']);
+			expect(group.files).to.include.members(['./**/test/**/*.implicit-group.js']);
 			expect(group.browsers).to.be.an('array').that.has.length(3);
 		});
 
@@ -44,7 +44,7 @@ describe('WTRConfig', () => {
 			const group = config.groups[0];
 			expect(config.groups).to.be.an('array').that.has.length(1);
 			expect(group.name).to.equal('a-group');
-			expect(group.files).to.include.members(['./test/**/*.a-group.js']);
+			expect(group.files).to.include.members(['./**/test/**/*.a-group.js']);
 		});
 
 		it('should enable nodeResolve to default', () => {
@@ -120,7 +120,7 @@ describe('WTRConfig', () => {
 		});
 
 		it('should set a common default files pattern', () => {
-			expect(config.groups[0].files).to.deep.equal([ './test/**/*.test.js', '!**/node_modules/**/*' ]);
+			expect(config.groups[0].files).to.deep.equal([ './**/test/**/*.test.js', '!**/node_modules/**/*' ]);
 		});
 
 		it('should run a given pattern function to set files', () => {
@@ -149,10 +149,10 @@ describe('WTRConfig', () => {
 
 		it('should filter test files using --filter values', () => {
 			const wtrConfig = new WTRConfig({ filter: ['subset', 'subset*'] });
-			const config = wtrConfig.create({ pattern: type => `./test/**/*/*.${type}.*` });
+			const config = wtrConfig.create({ pattern: type => `./**/test/**/*/*.${type}.*` });
 			expect(config.files).to.be.undefined;
 			expect(config.groups[0].files).to.have.length(3);
-			expect(config.groups[0].files).to.have.members(['./test/**/*/+(subset.test.*|*.test.subset)', './test/**/*/+(subset*.test.*|*.test.subset*)', '!**/node_modules/**/*']);
+			expect(config.groups[0].files).to.have.members(['./**/test/**/*/+(subset.test.*|*.test.subset)', './**/test/**/*/+(subset*.test.*|*.test.subset*)', '!**/node_modules/**/*']);
 		});
 
 		it('should never filter excluded files', () => {


### PR DESCRIPTION
[GAUD-9880](https://desire2learn.atlassian.net/browse/GAUD-9880): Generalize test runner to look for more test files

This change will match test directories at the root or buried at lower levels as in `core`.

Tested in core:
<img width="1404" height="762" alt="Screenshot 2026-05-07 at 1 40 16 PM" src="https://github.com/user-attachments/assets/fe91eed9-cb52-4c33-9ddc-a530b448485a" />


[GAUD-9880]: https://desire2learn.atlassian.net/browse/GAUD-9880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ