### PR TITLE
GAUD-10062: expose waitForElem

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ it('should work when printing', async() => {
 });
 ```
 
-### Accessibility Testing with aXe
+### Accessibility Testing with axe
 
-Elements can be processed by the [aXe accessibility validator](https://github.com/dequelabs/axe-core), which will automatically fail the test if any violations are detected.
+Elements can be processed by the [axe accessibility validator](https://github.com/dequelabs/axe-core), which will automatically fail the test if any violations are detected.
 
 ```javascript
 it('should be accessible', async() => {
@@ -299,6 +299,20 @@ it('should wait for updates', async() => {
   const elem = await fixture(html`<my-elem></my-elem>`);
   elem.someProp = 'foo';
   await elem.updateComplete;
+});
+```
+
+If that change causes a different set of nested components to be rendered, and those nested components take some time to finish *their* rendering, it's possible that awaiting `updateComplete` isn't enough.
+
+In this case, `waitForElem` can be used to recursively wait in a similar way to the original `fixture` call:
+
+```javascript
+import { fixture, waitForElem } from '@brightspace-ui/testing';
+
+it('should wait for recursive re-rendering', async() => {
+  const elem = await fixture(html`<my-elem></my-elem>`);
+  elem.errorState = true;
+  await waitForElem(elem);
 });
 ```
 

--- a/src/browser/fixture.js
+++ b/src/browser/fixture.js
@@ -42,14 +42,14 @@ export async function waitForElem(elem, awaitLoadingComplete = true) {
 
 	const doWait = async() => {
 
-		const update = elem.updateComplete;
-		if (typeof update === 'object' && Promise.resolve(update) === update) {
-			await update;
+		if (awaitLoadingComplete && typeof elem.getLoadingComplete === 'function') {
+			await elem.getLoadingComplete();
 			await nextFrame();
 		}
 
-		if (awaitLoadingComplete && typeof elem.getLoadingComplete === 'function') {
-			await elem.getLoadingComplete();
+		const update = elem.updateComplete;
+		if (typeof update === 'object' && Promise.resolve(update) === update) {
+			await update;
 			await nextFrame();
 		}
 

--- a/src/browser/fixture.js
+++ b/src/browser/fixture.js
@@ -36,7 +36,7 @@ function getComposedChildren(node) {
  * @param {*} elem
  * @param {boolean} awaitLoadingComplete
  */
-async function waitForElem(elem, awaitLoadingComplete = true) {
+export async function waitForElem(elem, awaitLoadingComplete = true) {
 
 	if (!elem) return;
 

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -3,5 +3,5 @@ import './axe.js';
 
 export { assert, aTimeout, defineCE, expect, html, nextFrame, oneDefaultPreventedEvent, oneEvent, waitUntil } from '@open-wc/testing';
 export { clickAt, clickElem, clickElemAt, dragDropElems, focusElem, hoverAt, hoverElem, hoverElemAt, sendKeys, sendKeysElem, setViewport } from './commands.js';
-export { fixture } from './fixture.js';
+export { fixture, waitForElem } from './fixture.js';
 export { runConstructor } from './constructor.js';

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -357,6 +357,7 @@ describe('fixture', () => {
 			const waitPromise = waitForElem(elem);
 			await waitUntil(() => resolves.has('slow'));
 			timeouts.push(setTimeout(() => resolves.get('slow')(), 50));
+			expect(elem.shadowRoot.querySelector(slowElem).finished).to.be.false;
 			await waitPromise;
 			expect(elem.shadowRoot.querySelector(slowElem).finished).to.be.true;
 		});

--- a/test/browser/fixture.test.js
+++ b/test/browser/fixture.test.js
@@ -1,5 +1,5 @@
 
-import { defineCE, expect, fixture, html, waitUntil } from '../../src/browser/index.js';
+import { defineCE, expect, fixture, html, waitForElem, waitUntil } from '../../src/browser/index.js';
 import { LitElement, nothing } from 'lit';
 import { restore, stub } from 'sinon';
 import { focusElem } from '../../src/browser/commands.js';
@@ -60,6 +60,24 @@ const removedElem = defineCE(
 		async getLoadingComplete() {
 			setTimeout(() => this.remove());
 			return new Promise(() => {});
+		}
+	}
+);
+
+const fastOrSlowElem = defineCE(
+	class extends LitElement {
+		static properties = {
+			slow: { type: Boolean }
+		};
+		constructor() {
+			super();
+			this.slow = false;
+		}
+		render() {
+			if (this.slow) {
+				return unsafeHTML(`<${slowElem} id="slow">slow</${slowElem}>`);
+			}
+			return html`<p>fast</p>`;
 		}
 	}
 );
@@ -330,6 +348,17 @@ describe('fixture', () => {
 		it('should abort waiting if elements are removed before getLoadingComplete', async() => {
 			const elem = await fixture(`<div><${removedElem}></${removedElem}></div>`);
 			expect(elem.querySelector(removedElem)).to.be.null;
+		});
+
+		it('should wait for elements that are updated to be slow', async() => {
+			const elem = await fixture(`<${fastOrSlowElem}></${fastOrSlowElem}>`);
+			expect(elem.shadowRoot.querySelector('p').textContent).to.equal('fast');
+			elem.slow = true;
+			const waitPromise = waitForElem(elem);
+			await waitUntil(() => resolves.has('slow'));
+			timeouts.push(setTimeout(() => resolves.get('slow')(), 50));
+			await waitPromise;
+			expect(elem.shadowRoot.querySelector(slowElem).finished).to.be.true;
 		});
 
 	});


### PR DESCRIPTION
In somewhat rare circumstances, changing a component's state can cause a totally different set of components within it to render. One example might be putting it into an error state. When this happens, awaiting `updateComplete` isn't often enough, as those *new* nested components might have language terms that need to load or they may need to do their own asynchronous work.

To solve this, we expose `waitForElem` -- which is already used internally by the original `fixture` call.