### PR TITLE
GAUD-10114: fix test categories

### DIFF
--- a/d2l-test-reporting.config.json
+++ b/d2l-test-reporting.config.json
@@ -2,15 +2,15 @@
   "tool": "UI Platform & Components",
   "overrides": [
     {
-      "pattern": "**/test/*.test.js",
+      "pattern": "./test/**/*.test.js",
       "type": "UI Unit"
     },
     {
-      "pattern": "**/test/*.axe.js",
+      "pattern": "./test/**/*.axe.js",
       "type": "UI Accessibility"
     },
     {
-      "pattern": "**/test/*.vdiff.js",
+      "pattern": "./test/**/*.vdiff.js",
       "type": "UI Visual Diff"
     }
   ]


### PR DESCRIPTION
These patterns weren't getting a hit since this repo is organized a bit differently, so they were falling until the "Other" category.