### PR TITLE
GAUD-10114: fix test categories

### DIFF
--- a/d2l-test-reporting.config.json
+++ b/d2l-test-reporting.config.json
@@ -2,6 +2,10 @@
   "tool": "UI Platform & Components",
   "overrides": [
     {
+      "pattern": "./test/**/*.ctor.js",
+      "type": "UI Unit"
+    },
+    {
       "pattern": "./test/**/*.test.js",
       "type": "UI Unit"
     },


### PR DESCRIPTION
There are 3 tests with `*.ctor.js` instead of `*.test.js` that the test reporting stuff is still treating as "other" instead of "unit" tests.