### PR TITLE
await localeData + real RTL check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -265,8 +265,8 @@
       }
     },
     "node_modules/@brightspace-ui/intl": {
-      "version": "3.40.1",
-      "integrity": "sha512-DNLlrexopVOPHLYArE1UaC/h1JPwCRgTFDZPzPsLgp+cjQqSkp4K/35YMlb8f6KkWKZy5nL4mc2n18YCWtMlWQ==",
+      "version": "3.42.0",
+      "integrity": "sha512-Wmj7Qy7qnol1CrvyA6s+Y7jrlrMRkinnQoQkuo5fXPWWD3CRf8z0cR9nN+jtmRcHq7wSZBB5iBtt0zolt7GqIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "intl-messageformat": "^11"

--- a/src/browser/reset.js
+++ b/src/browser/reset.js
@@ -1,5 +1,6 @@
 import { setViewport as cmdSetViewport, emulateMedia, sendMouse } from '@web/test-runner-commands';
 import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
+import { localeData } from '@brightspace-ui/intl/lib/locale-data/current.js';
 import { nextFrame } from '@open-wc/testing';
 
 const DEFAULT_PAGE_PADDING = true,
@@ -48,7 +49,6 @@ export async function reset(opts = {}) {
 	const defaultOpts = {
 		lang: DEFAULT_LANG,
 		mathjax: {},
-		rtl: !!opts.lang?.startsWith('ar'),
 		colorMode: DEFAULT_COLOR_MODE,
 		pagePadding: DEFAULT_PAGE_PADDING,
 		media: DEFAULT_MEDIA
@@ -82,16 +82,6 @@ export async function reset(opts = {}) {
 		awaitNextFrame = true;
 	}
 
-	if (opts.rtl !== currentRtl) {
-		if (!opts.rtl) {
-			document.documentElement.removeAttribute('dir');
-		} else {
-			document.documentElement.setAttribute('dir', 'rtl');
-		}
-		awaitNextFrame = true;
-		currentRtl = opts.rtl;
-	}
-
 	if (opts.colorMode !== currentColorMode) {
 		const colorMode = ['light', 'dark'].includes(opts.colorMode) ? opts.colorMode : DEFAULT_COLOR_MODE;
 		if (!colorMode) {
@@ -106,7 +96,18 @@ export async function reset(opts = {}) {
 	opts.lang ??= '';
 	if (documentLocaleSettings.language !== opts.lang) {
 		document.documentElement.lang = opts.lang;
+		await localeData;
+	}
+
+	opts.rtl ??= localeData.layout.orientation.characterOrder === 'right-to-left';
+	if (opts.rtl !== currentRtl) {
+		if (!opts.rtl) {
+			document.documentElement.removeAttribute('dir');
+		} else {
+			document.documentElement.setAttribute('dir', 'rtl');
+		}
 		awaitNextFrame = true;
+		currentRtl = opts.rtl;
 	}
 
 	if (await setViewport(opts.viewport)) {

--- a/test/browser/ctor.config.js
+++ b/test/browser/ctor.config.js
@@ -2,7 +2,7 @@ export default {
 	pattern: () => 'test/browser/**/*.ctor.js',
 	testRunnerHtml: testFramework =>
 		`<!DOCTYPE html>
-		<html>
+		<html lang="en">
 			<body>
 				<script>
 				window.addEventListener('error', (err) => {


### PR DESCRIPTION
[GAUD-9717](https://desire2learn.atlassian.net/browse/GAUD-9717): Rewrite intl/common and intl/dateTime to use contained data sets per locale

Since `fixture` already handles (re)setting the language it makes sense to have it handle waiting for locale data so consumers get this for free as well.

Also changes the RTL logic to pull the actual locale layout data.

[GAUD-9717]: https://desire2learn.atlassian.net/browse/GAUD-9717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ